### PR TITLE
feat(错误处理): 移动上传日志功能按钮位置并包含所有崩溃类型

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/ErrorActivity.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/ErrorActivity.kt
@@ -26,11 +26,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import com.jakewharton.processphoenix.ProcessPhoenix
 import com.movtery.zalithlauncher.R
 import com.movtery.zalithlauncher.context.COPY_LABEL_LINK
@@ -142,11 +140,15 @@ class ErrorActivity : BaseAppCompatActivity(refreshData = false) {
                         viewModel = viewModel,
                         crashType = errorMessage.crashType,
                         shareLogs = logFile.exists() && logFile.isFile,
+                        canUpload = viewModel.canUpload,
                         canRestart = canRestart,
                         onShareLogsClick = {
                             if (logFile.exists() && logFile.isFile) {
                                 shareFile(this@ErrorActivity, logFile)
                             }
+                        },
+                        onUploadClick = {
+                            viewModel.operation = ShareLinkOperation.Tip
                         },
                         onRestartClick = {
                             ProcessPhoenix.triggerRebirth(this@ErrorActivity)
@@ -161,15 +163,6 @@ class ErrorActivity : BaseAppCompatActivity(refreshData = false) {
                             text = errorMessage.messageBody,
                             style = MaterialTheme.typography.bodyMedium
                         )
-                        if (viewModel.canUpload) {
-                            Button(
-                                onClick = {
-                                    viewModel.operation = ShareLinkOperation.Tip
-                                }
-                            ) {
-                                Text(text = stringResource(R.string.crash_link_share_button))
-                            }
-                        }
                     }
                 }
             }

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/main/ErrorScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/main/ErrorScreen.kt
@@ -69,8 +69,10 @@ fun ErrorScreen(
     viewModel: CrashLogsUploadViewModel,
     crashType: CrashType,
     shareLogs: Boolean = true,
+    canUpload: Boolean = false,
     canRestart: Boolean = true,
     onShareLogsClick: () -> Unit = {},
+    onUploadClick: () -> Unit = {},
     onRestartClick: () -> Unit = {},
     onExitClick: () -> Unit = {},
     body: @Composable ColumnScope.() -> Unit
@@ -83,8 +85,10 @@ fun ErrorScreen(
         ErrorScreenLandscape(
             crashType = crashType,
             shareLogs = shareLogs,
+            canUpload = canUpload,
             canRestart = canRestart,
             onShareLogsClick = onShareLogsClick,
+            onUploadClick = onUploadClick,
             onRestartClick = onRestartClick,
             onExitClick = onExitClick,
             body = body
@@ -93,8 +97,10 @@ fun ErrorScreen(
         ErrorScreenPortrait(
             crashType = crashType,
             shareLogs = shareLogs,
+            canUpload = canUpload,
             canRestart = canRestart,
             onShareLogsClick = onShareLogsClick,
+            onUploadClick = onUploadClick,
             onRestartClick = onRestartClick,
             onExitClick = onExitClick,
             body = body
@@ -109,8 +115,10 @@ fun ErrorScreen(
 private fun ErrorScreenLandscape(
     crashType: CrashType,
     shareLogs: Boolean,
+    canUpload: Boolean,
     canRestart: Boolean,
     onShareLogsClick: () -> Unit,
+    onUploadClick: () -> Unit,
     onRestartClick: () -> Unit,
     onExitClick: () -> Unit,
     body: @Composable ColumnScope.() -> Unit
@@ -151,8 +159,10 @@ private fun ErrorScreenLandscape(
                         .padding(all = 12.dp),
                     crashType = crashType,
                     shareLogs = shareLogs,
+                    canUpload = canUpload,
                     canRestart = canRestart,
                     onShareLogsClick = onShareLogsClick,
+                    onUploadClick = onUploadClick,
                     onRestartClick = onRestartClick,
                     onExitClick = onExitClick
                 )
@@ -169,8 +179,10 @@ private fun ErrorScreenLandscape(
 private fun ErrorScreenPortrait(
     crashType: CrashType,
     shareLogs: Boolean,
+    canUpload: Boolean,
     canRestart: Boolean,
     onShareLogsClick: () -> Unit,
+    onUploadClick: () -> Unit,
     onRestartClick: () -> Unit,
     onExitClick: () -> Unit,
     body: @Composable ColumnScope.() -> Unit
@@ -203,6 +215,17 @@ private fun ErrorScreenPortrait(
                         expanded = showMenu,
                         onDismissRequest = { showMenu = false }
                     ) {
+                        if (canUpload) {
+                            DropdownMenuItem(
+                                text = {
+                                    MarqueeText(text = stringResource(R.string.crash_link_share_button))
+                                },
+                                onClick = {
+                                    showMenu = false
+                                    onUploadClick()
+                                }
+                            )
+                        }
                         DropdownMenuItem(
                             text = {
                                 MarqueeText(text = stringResource(R.string.crash_share_logs))
@@ -324,8 +347,10 @@ private fun ActionContext(
     modifier: Modifier = Modifier,
     crashType: CrashType,
     shareLogs: Boolean,
+    canUpload: Boolean,
     canRestart: Boolean,
     onShareLogsClick: () -> Unit = {},
+    onUploadClick: () -> Unit = {},
     onRestartClick: () -> Unit = {},
     onExitClick: () -> Unit = {}
 ) {
@@ -353,6 +378,15 @@ private fun ActionContext(
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.Bottom
         ) {
+            if (canUpload) {
+                ScalingActionButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = onUploadClick
+                ) {
+                    MarqueeText(text = stringResource(R.string.crash_link_share_button))
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+            }
             if (shareLogs) {
                 ScalingActionButton(
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
已经测试了（应用崩溃愣是没搞出来））

这样做的目的也是让应用崩溃也能上传日志（虽然感觉没多大用处）