### PR TITLE
fix: 部分设备无法正常关闭全屏

### DIFF
--- a/ZalithLauncher/build.gradle.kts
+++ b/ZalithLauncher/build.gradle.kts
@@ -71,7 +71,7 @@ android {
         applicationId = zalithPackageName
         applicationIdSuffix = ".v2"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 34
         versionCode = launcherVersionCode
         versionName = launcherVersionName
         manifestPlaceholders["launcher_name"] = launcherAPPName

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/base/FullScreenAppCompatActivity.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/base/FullScreenAppCompatActivity.kt
@@ -23,6 +23,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
 import androidx.annotation.CallSuper
+import androidx.annotation.RequiresApi
 
 enum class WindowMode {
     DEFAULT,
@@ -65,36 +66,59 @@ abstract class FullScreenAppCompatActivity : AbstractAppCompatActivity() {
     @Suppress("DEPRECATION")
     private fun applyFullscreen(mode: WindowMode) {
         if (window != null) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                val params = window.attributes
-                val newParams = when (mode) {
-                    WindowMode.DEFAULT -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
-                    WindowMode.FULL_IMMERSIVE -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-                }
-                if (params.layoutInDisplayCutoutMode != newParams) {
-                    params.layoutInDisplayCutoutMode = newParams
-                    window.attributes = params
-                }
-            }
-
             when (mode) {
                 WindowMode.DEFAULT -> {
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
-                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN) //隐藏状态栏
-                    window.decorView.systemUiVisibility = (
-                            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                                    or View.SYSTEM_UI_FLAG_FULLSCREEN
-                                    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                            )
+                    applyDefault()
                 }
                 WindowMode.FULL_IMMERSIVE -> {
-                    window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
-                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-                    window.decorView.systemUiVisibility = systemUIVisibility
+                    if (isInMultiWindowMode) {
+                        applyDefault()
+                    } else {
+                        applyFullImmersive()
+                    }
                 }
             }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun applyDefault() {
+        if (window != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                applyWindowAttributes(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER)
+            }
+
+            window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
+            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN) //隐藏状态栏
+            window.decorView.systemUiVisibility = (
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                            or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                            or View.SYSTEM_UI_FLAG_FULLSCREEN
+                            or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                    )
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun applyFullImmersive() {
+        if (window != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                applyWindowAttributes(WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES)
+            }
+
+            window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
+            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+            window.decorView.systemUiVisibility = systemUIVisibility
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private fun applyWindowAttributes(newParams: Int) {
+        val params = window.attributes
+        if (params.layoutInDisplayCutoutMode != newParams) {
+            params.layoutInDisplayCutoutMode = newParams
+            window.attributes = params
         }
     }
 

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/base/FullScreenAppCompatActivity.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/base/FullScreenAppCompatActivity.kt
@@ -66,16 +66,35 @@ abstract class FullScreenAppCompatActivity : AbstractAppCompatActivity() {
     private fun applyFullscreen(mode: WindowMode) {
         if (window != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                val params = window.attributes.apply {
-                    this.layoutInDisplayCutoutMode = when (mode) {
-                        WindowMode.DEFAULT -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
-                        WindowMode.FULL_IMMERSIVE -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
-                    }
+                val params = window.attributes
+                val newParams = when (mode) {
+                    WindowMode.DEFAULT -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+                    WindowMode.FULL_IMMERSIVE -> WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
                 }
-                window.attributes = params
+                if (params.layoutInDisplayCutoutMode != newParams) {
+                    params.layoutInDisplayCutoutMode = newParams
+                    window.attributes = params
+                }
             }
-            window.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN, WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
-            window.decorView.systemUiVisibility = systemUIVisibility
+
+            when (mode) {
+                WindowMode.DEFAULT -> {
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
+                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN) //隐藏状态栏
+                    window.decorView.systemUiVisibility = (
+                            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                                    or View.SYSTEM_UI_FLAG_FULLSCREEN
+                                    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+                            )
+                }
+                WindowMode.FULL_IMMERSIVE -> {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN)
+                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+                    window.decorView.systemUiVisibility = systemUIVisibility
+                }
+            }
         }
     }
 

--- a/ZalithLauncher/src/main/res/values/themes.xml
+++ b/ZalithLauncher/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="AppTheme.ZalithLauncher" parent="Theme.Material3.Light.NoActionBar">
-        <item name="android:windowFullscreen">true</item>
+        <!-- <item name="android:windowFullscreen">true</item> -->
         <item name="android:windowContentOverlay">@null</item>
     </style>
     <style name="AppTheme.SplashScreen" parent="@style/Theme.SplashScreen">
@@ -10,7 +10,7 @@
         <item name="windowSplashScreenAnimationDuration">200</item>
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:windowFullscreen">true</item>
+        <!-- <item name="android:windowFullscreen">true</item> -->
         <item name="android:windowContentOverlay">@null</item>
     </style>
 </resources>


### PR DESCRIPTION
targetSdk大于等于35时，会强制使用enableEdgeToEdge()，导致部分设备无法禁用全屏，现已降级到34
同时，稍微改进了一下全屏控制逻辑