### PR TITLE
fix: 更新中国区最新版本API的URL地址

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/viewmodel/LauncherUpgradeViewModel.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/viewmodel/LauncherUpgradeViewModel.kt
@@ -81,7 +81,7 @@ sealed interface LauncherUpgradeOperation {
  */
 private const val LATEST_VERSION = "latest_version_md.json"
 private const val LATEST_API_URL = "$URL_PROJECT_INFO/$LATEST_VERSION"
-private const val LATEST_API_CHINESE_URL = "https://fcl.lemwood.cn/zalith-info/v2/$LATEST_VERSION"
+private const val LATEST_API_CHINESE_URL = "https://repo.miawa.cn/zalith-info/v2/$LATEST_VERSION"
 
 /**
  * 用于记录启动器更新 ViewModel


### PR DESCRIPTION
将中国区最新版本API的URL地址从fcl.lemwood.cn更改为repo.miawa.cn