### PR TITLE
ci: remove deprecated action warning by bump action to latest major version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: "17"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           add-job-summary: "on-failure"
 
@@ -57,7 +57,7 @@ jobs:
       - name: Upload Release APK for ${{ matrix.arch }}
         if: inputs.variant == 'Release'
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release apk (${{ matrix.arch }})
           path: ZalithLauncher/build/outputs/apk/release/*.apk
@@ -65,7 +65,7 @@ jobs:
       - name: Upload Debug APK for ${{ matrix.arch }}
         if: inputs.variant == 'Debug'
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debug apk (${{ matrix.arch }})
           path: ZalithLauncher/build/outputs/apk/debug/*.apk

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -45,7 +45,7 @@ jobs:
           echo "Found $(ls ./apks/ | wc -l) APK file(s)"
 
       - name: Upload To Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: ./apks/*.apk

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Download Files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./artifacts
 


### PR DESCRIPTION
Bumped actions:
- `checkout`
- `upload-artifact`
- `download-artifact`
- `setup-java`
- `setup-gradle`
- `action-gh-release`
Reason:
Because i want to remove deprecated warning when using ci to build pushed commit.
There changes are safe and stable. No breaking changes and tested