### PR TITLE
fix: 主菜单内版本列表组件相关的问题

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/LauncherScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/LauncherScreen.kt
@@ -298,7 +298,9 @@ private fun RightMenuContent(
                     VersionManagerLayout(
                         isRefreshing = isRefreshing,
                         version = version,
-                        modifier = Modifier.padding(8.dp),
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .fillMaxWidth(),
                         swapToVersionManage = toVersionManageScreen,
                         openListMenu = { showList = true },
                     )

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/LauncherScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/LauncherScreen.kt
@@ -437,7 +437,9 @@ private fun VersionManagerLayout(
             .combinedClickable(
                 role = Role.Button,
                 onClick = swapToVersionManage,
-                onLongClick = openListMenu
+                onLongClick = {
+                    if (version != null) openListMenu()
+                }
             )
             .padding(PaddingValues(all = 8.dp))
     ) {


### PR DESCRIPTION
- 组件宽度未占满父容器宽度
- 未安装版本时，长按仍会打开版本列表菜单