### PR TITLE
chore(ci): bump `actions/checkout` from 6 to 7 in `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 


### PR DESCRIPTION
Checkout v7
What's new
Safer fork pull request handling: checkout now refuses to check out fork pull request code by default when the workflow is triggered by pull_request_target or workflow_run. These triggers run with the base repository's GITHUB_TOKEN, secrets, and runner access, where executing a fork's code commonly leads to "pwn request" vulnerabilities.
To opt in after [reviewing the risks](https://gh.io/securely-using-pull_request_target), set the new allow-unsafe-pr-checkout: true input.
Migrated actions/checkout to ESM to support new versions of the @actions/* packages.
Updated direct and transitive dependencies, including security fixes for known vulnerabilities.