### PR TITLE
fix: 修复部分设备多点触控时控制按钮坐标偏移

### DIFF
--- a/LayerController/src/main/java/com/movtery/layer_controller/Layout.kt
+++ b/LayerController/src/main/java/com/movtery/layer_controller/Layout.kt
@@ -31,15 +31,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.IntSize
@@ -149,6 +154,7 @@ private fun BoxWithConstraintsScope.BaseControlBoxLayout(
     val currentHideLayerWhen by rememberUpdatedState(hideLayerWhen)
 
     val density = LocalDensity.current
+    val layoutPositionInRoot = remember { mutableStateOf(Offset.Zero) }
     val screenSize = remember(maxWidth, maxHeight) {
         with(density) {
             IntSize(
@@ -168,12 +174,16 @@ private fun BoxWithConstraintsScope.BaseControlBoxLayout(
 
     Box(
         modifier = modifier
+            .onGloballyPositioned { coordinates ->
+                layoutPositionInRoot.value = coordinates.positionInRoot()
+            }
             .pointerInput(reversedLayers, hideLayerWhen) {
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent(pass = PointerEventPass.Initial)
+                        val motionEvent = event.motionEvent
 
-                        event.changes.forEach { change ->
+                        event.changes.forEachIndexed { index, change ->
                             val pointerId = change.id
                             //手指抬起，清理该指针所有状态
                             if (!change.pressed) {
@@ -181,11 +191,11 @@ private fun BoxWithConstraintsScope.BaseControlBoxLayout(
                                     //释放该指针事件
                                     widget.onReleaseEvent(eventHandler, reversedLayers)
                                 }
-                                return@forEach
+                                return@forEachIndexed
                             }
 
                             if (change.isConsumed || currentCheckOccupiedPointers(pointerId)) {
-                                return@forEach //跳过已消费或被占用的指针
+                                return@forEachIndexed //跳过已消费或被占用的指针
                             }
 
                             //收集可见控件
@@ -196,9 +206,26 @@ private fun BoxWithConstraintsScope.BaseControlBoxLayout(
                                 isCursorGrabbing = currentIsCursorGrabbing,
                             )
 
+                            // Compose reconstructs Android pointer positions from raw screen
+                            // coordinates. Some devices expose raw and local coordinates with
+                            // different scaling, which corrupts secondary pointer positions.
+                            val position = if (
+                                change.type == PointerType.Touch &&
+                                motionEvent != null &&
+                                index < motionEvent.pointerCount
+                            ) {
+                                Offset(
+                                    x = motionEvent.getX(index) - layoutPositionInRoot.value.x,
+                                    y = motionEvent.getY(index) - layoutPositionInRoot.value.y,
+                                )
+                            } else {
+                                change.position
+                            }
+
                             touchProcessor.processFrame(
                                 session = touchSession,
                                 change = change,
+                                position = position,
                                 visibleWidgets = visibleWidgets,
                                 allLayers = reversedLayers,
                                 consumeEvent = { it.consume() },

--- a/LayerController/src/main/java/com/movtery/layer_controller/observable/TouchProcessor.kt
+++ b/LayerController/src/main/java/com/movtery/layer_controller/observable/TouchProcessor.kt
@@ -44,6 +44,7 @@ class TouchProcessor(
 
     /**
      * 处理单帧指针事件
+     * @param position 当前指针相对于控制布局的位置
      * @param visibleWidgets 预过滤后的可见控件列表
      * @param allLayers 所有控件层
      * @param consumeEvent 消费事件的回调
@@ -52,13 +53,13 @@ class TouchProcessor(
     fun processFrame(
         session: TouchSession,
         change: PointerInputChange,
+        position: Offset = change.position,
         visibleWidgets: List<ObservableWidget>,
         allLayers: List<ObservableControlLayer>,
         consumeEvent: (PointerInputChange) -> Unit,
         markPointerAsMoveOnly: (PointerId) -> Unit,
     ) {
         val pointerId = change.id
-        val position = change.position
 
         //获取指针命中的目标控件
         val targets = findTargets(visibleWidgets, position)


### PR DESCRIPTION
## 问题

在部分设备上使用多点触控时，控制按钮接收到的第二根及后续手指坐标会发生偏移。

具体表现：

- 第一根手指坐标始终正确。
- 后续手指距离第一根越远，偏移越明显。
- 后续手指保持不动时，移动第一根手指也会改变后续手指的 Compose 坐标。
- 单指触控不受影响。

https://github.com/user-attachments/assets/12129bd3-18b2-4a7a-86ec-098d3a0d09b7

Fixes #1521

## 原因

设备提供的 `MotionEvent.getX(index)` / `getY(index)` 局部坐标是正确的，但 Compose 的 `PointerInputChange.position` 已经发生偏移。

当前 Compose Android 输入实现会通过 `getRawX(index)` / `getRawY(index)` 和 `screenToLocal()` 重建指针坐标。在受影响的环境中，raw 屏幕坐标和 View 局部坐标之间存在额外缩放，导致第一个指针正常、后续指针相对第一个指针产生偏移。

## 修复

控制按钮的命中和越界判断对触摸输入使用当前帧的：

```kotlin
MotionEvent.getX(index)
MotionEvent.getY(index)