### PR TITLE
Support for high refresh rates on some devices.

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/VMActivity.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/VMActivity.kt
@@ -339,7 +339,9 @@ class VMActivity : BaseAppCompatActivity(), SurfaceTextureListener, SurfaceHolde
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.attributes = window.attributes.apply { preferredRefreshRate = 120f }
+        display?.supportedModes?.maxOfOrNull { it.refreshRate }?.let { refreshRate ->
+            window.attributes = window.attributes.apply { preferredRefreshRate = refreshRate }
+        }
         //加载渲染器
         Renderers.init()
         //加载插件

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/VMActivity.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/VMActivity.kt
@@ -339,6 +339,7 @@ class VMActivity : BaseAppCompatActivity(), SurfaceTextureListener, SurfaceHolde
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.attributes = window.attributes.apply { preferredRefreshRate = 120f }
         //加载渲染器
         Renderers.init()
         //加载插件

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/VMActivity.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/activities/VMActivity.kt
@@ -339,9 +339,11 @@ class VMActivity : BaseAppCompatActivity(), SurfaceTextureListener, SurfaceHolde
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        display?.supportedModes?.maxOfOrNull { it.refreshRate }?.let { refreshRate ->
-            window.attributes = window.attributes.apply { preferredRefreshRate = refreshRate }
-        }
+        windowManager.defaultDisplay?.supportedModes
+            ?.maxOfOrNull { it.refreshRate }
+            ?.let { refreshRate ->
+                window.attributes = window.attributes.apply { preferredRefreshRate = refreshRate }
+            }
         //加载渲染器
         Renderers.init()
         //加载插件


### PR DESCRIPTION
Fixes Minecraft being limited to 60 Hz by requesting 120 Hz for VMActivity.

Android defaults games without an explicit refresh-rate preference to 60 Hz. This may also bypass some vendor-specific game nonsense, such as OnePlus Game Mode.

Running the game at 60 FPS may add minor overhead, since the display still refreshes at 120 Hz. However, without this, the game can run at 500 FPS while being capped to a 60 Hz display, which is worse in my opinion.

Possible better alternatives could be:
Use the in-game settings to determine the requested refresh rate.
Add a user-facing setting to choose it.