### PR TITLE
修复 26.3 快照缺少 LWJGL SDL 类导致的启动崩溃

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/launch/LaunchArgs.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/launch/LaunchArgs.kt
@@ -33,6 +33,7 @@ import com.movtery.zalithlauncher.game.plugin.natives.NativePluginManager
 import com.movtery.zalithlauncher.game.version.download.artifactToPath
 import com.movtery.zalithlauncher.game.version.download.filterLibrary
 import com.movtery.zalithlauncher.game.version.download.getLibraryReplacement
+import com.movtery.zalithlauncher.game.version.download.usesLwjglSdl
 import com.movtery.zalithlauncher.game.version.installed.Version
 import com.movtery.zalithlauncher.game.version.installed.VersionInfo
 import com.movtery.zalithlauncher.game.version.installed.VersionInfoParser
@@ -223,7 +224,14 @@ class LaunchArgs(
 //        }
 
         val varArgMap: MutableMap<String, String> = android.util.ArrayMap()
-        val launchClassPath = "${getLWJGL3ClassPath()}:${generateLaunchClassPath(gameManifest)}"
+        val gameClassPath = generateLaunchClassPath(gameManifest)
+        val lwjglClassPath = getLWJGL3ClassPath()
+        val launchClassPath = if (gameManifest.libraries.usesLwjglSdl()) {
+            // SDL 绑定依赖同版本的 LWJGL Core，优先加载后再回退到启动器的 Android 兼容实现。
+            "$gameClassPath:$lwjglClassPath"
+        } else {
+            "$lwjglClassPath:$gameClassPath"
+        }
         var hasClasspath = false //是否已经在jvm参数中包含 ${classpath} 配置
 
         varArgMap["classpath_separator"] = ":"
@@ -297,10 +305,11 @@ class LaunchArgs(
     private fun generateLibClasspath(gameManifest: GameManifest): Array<String> {
         val libSortFix = LibSortFix(version.getVersionInfo())
         val libs = LinkedHashMap<GameManifest.Library, String>()
+        val usesLwjglSdl = gameManifest.libraries.usesLwjglSdl()
 
         for (libItem in gameManifest.libraries) {
             if (!(GameManifest.Rule.checkRules(libItem.rules) && !libItem.isNative)) continue
-            val path = libItem.progressLibrary() ?: continue
+            val path = libItem.progressLibrary(allowLwjglSdlClasses = usesLwjglSdl) ?: continue
             with(libSortFix) {
                 libs.insertLib(libItem, getLibrariesHome() + "/" + path)
             }
@@ -313,8 +322,8 @@ class LaunchArgs(
     /**
      * @return 库相对路径
      */
-    private fun GameManifest.Library.progressLibrary(): String? {
-        if (filterLibrary()) return null
+    private fun GameManifest.Library.progressLibrary(allowLwjglSdlClasses: Boolean): String? {
+        if (filterLibrary(allowLwjglSdlClasses)) return null
 
         var path = artifactToPath(this)
 

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/version/download/BaseMinecraftDownloader.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/version/download/BaseMinecraftDownloader.kt
@@ -152,10 +152,11 @@ class BaseMinecraftDownloader(
     ) {
         gameManifest.libraries?.let { libraries ->
             processLibraries { libraries }
+            val usesLwjglSdl = libraries.usesLwjglSdl()
             libraries.forEach { library ->
                 currentCoroutineContext().ensureActive()
 
-                if (library.name.startsWith("org.lwjgl")) return@forEach
+                if (library.filterLibrary(allowLwjglSdlClasses = usesLwjglSdl)) return@forEach
 
                 val artifactPath: String = artifactToPath(library) ?: return@forEach
                 val (sha1: String?, url, size, isDownloadable) = library.downloads?.let { downloads ->

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/version/download/_LibraryReplacement.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/version/download/_LibraryReplacement.kt
@@ -67,13 +67,31 @@ fun getLibraryReplacement(libraryName: String, versionParts: List<String>): Libr
 }
 
 /**
+ * 新版 SDL 绑定依赖与其同版本的 LWJGL Core。
+ */
+internal fun List<GameManifest.Library>.usesLwjglSdl(): Boolean = any { library ->
+    library.name?.split(":")?.let { coordinates ->
+        coordinates.size == 3 &&
+            coordinates[0] == "org.lwjgl" &&
+            coordinates[1] == "lwjgl-sdl"
+    } == true
+}
+
+/**
  * @return 是否需要被过滤
  */
-fun GameManifest.Library.filterLibrary(): Boolean {
+fun GameManifest.Library.filterLibrary(allowLwjglSdlClasses: Boolean = false): Boolean {
+    val libraryName = name ?: return false
+    val coordinates = libraryName.split(":")
+    val isLwjglSdlClasses = coordinates.size == 3 &&
+        coordinates[0] == "org.lwjgl" &&
+        (coordinates[1] == "lwjgl" || coordinates[1] == "lwjgl-sdl") &&
+        !isNative
+
     return when {
-        name?.contains("org.lwjgl") == true -> true
-        name?.contains("jinput-platform") == true -> true
-        name?.contains("twitch-platform") == true -> true
+        coordinates.firstOrNull() == "org.lwjgl" -> !(allowLwjglSdlClasses && isLwjglSdlClasses)
+        libraryName.contains("jinput-platform") -> true
+        libraryName.contains("twitch-platform") -> true
         else -> false
     }
 }

--- a/ZalithLauncher/src/test/java/com/movtery/zalithlauncher/game/version/download/LibraryFilterTest.kt
+++ b/ZalithLauncher/src/test/java/com/movtery/zalithlauncher/game/version/download/LibraryFilterTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Zalith Launcher 2
+ * Copyright (C) 2025 MovTery <movtery228@qq.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.movtery.zalithlauncher.game.version.download
+
+import com.movtery.zalithlauncher.game.versioninfo.models.GameManifest
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+
+class LibraryFilterTest {
+
+    @Test
+    fun lwjglCoreAndSdlClassesAreKeptForSdlVersions() {
+        assertFalse(library("org.lwjgl:lwjgl:3.4.2").filterLibrary(allowLwjglSdlClasses = true))
+        assertFalse(library("org.lwjgl:lwjgl-sdl:3.4.2").filterLibrary(allowLwjglSdlClasses = true))
+    }
+
+    @Test
+    fun otherLwjglModulesRemainFilteredForSdlVersions() {
+        assertTrue(library("org.lwjgl:lwjgl-opengl:3.4.2").filterLibrary(allowLwjglSdlClasses = true))
+        assertTrue(library("org.lwjgl:lwjgl-openal:3.4.2").filterLibrary(allowLwjglSdlClasses = true))
+    }
+
+    @Test
+    fun lwjglDesktopNativesRemainFiltered() {
+        assertTrue(library("org.lwjgl:lwjgl-sdl:3.4.2:natives-linux").filterLibrary(allowLwjglSdlClasses = true))
+        assertTrue(library("org.lwjgl:lwjgl-sdl:3.4.2:natives-windows-arm64").filterLibrary(allowLwjglSdlClasses = true))
+    }
+
+    @Test
+    fun bundledLwjglRemainsTheDefault() {
+        assertTrue(library("org.lwjgl:lwjgl:3.4.2").filterLibrary())
+        assertTrue(library("org.lwjgl:lwjgl-opengl:3.4.2").filterLibrary())
+    }
+
+    @Test
+    fun unrelatedLibrariesAreKept() {
+        assertFalse(library("com.example:org.lwjgl.helper:1.0.0").filterLibrary())
+    }
+
+    @Test
+    fun sdlBindingSelectsCurrentLwjglClasses() {
+        assertTrue(
+            listOf(
+                library("org.lwjgl:lwjgl:3.4.2"),
+                library("org.lwjgl:lwjgl-sdl:3.4.2")
+            ).usesLwjglSdl()
+        )
+        assertFalse(listOf(library("org.lwjgl:lwjgl-glfw:3.3.6")).usesLwjglSdl())
+    }
+
+    private fun library(coordinates: String) = GameManifest.Library().apply {
+        name = coordinates
+    }
+}


### PR DESCRIPTION
## 问题

26.3 Snapshot 7/8 引入了 `org.lwjgl:lwjgl-sdl:3.4.2`。启动器目前会过滤 Mojang 提供的 LWJGL 库，改用内置的 Android 兼容版本；但内置版本不包含 SDL 绑定，最终在加载 SDL 时因为找不到 `org.lwjgl.sdl.SDL` 和 `SDLPlatform` 崩溃。

只补 `lwjgl-sdl` 也不够，它还依赖同版本 LWJGL Core 中的 `Configuration` 和回调相关 API。

## 修改

- 根据版本清单中是否存在 `lwjgl-sdl` 判断是否启用兼容处理
- SDL 版本仅保留同版本的 `lwjgl` Core 和 `lwjgl-sdl` Java JAR，并放在内置兼容 JAR 之前
- 继续过滤桌面 Native classifier 和其他 LWJGL 模块，避免覆盖启动器现有的 Android OpenGL/OpenAL 实现
- 非 SDL 版本保持原有下载及 classpath 行为
- 增加 SDL 检测、库过滤和旧版本行为测试

## 验证

- `./gradlew :ZalithLauncher:testDebugUnitTest --tests 'com.movtery.zalithlauncher.game.version.download.LibraryFilterTest'`
- `./gradlew :ZalithLauncher:assembleDebug -Darch=arm64`
- ARM64 APK 中已确认包含 `libSDL3.so` 和 `liblwjgl.so`

目前没有对应的 Android 真机环境，尚未验证进入游戏后的 SDL 窗口及输入行为。

Closes #1668