### PR TITLE
fix: “搜索ID”屏幕跳转的项目页面内下载会锁定到模组文件夹

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/DownloadScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/DownloadScreen.kt
@@ -307,7 +307,7 @@ private fun NavigationUI(
                                         NormalNavKey.DownloadAssets(
                                             platform = platform,
                                             projectId = projectId,
-                                            classes = PlatformClasses.MOD,
+                                            classes = classes,
                                             iconUrl = iconUrl
                                         )
                                     )

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/elements/_Download.Single.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/elements/_Download.Single.kt
@@ -153,8 +153,10 @@ fun DownloadSingleOperation(
             )
         }
         is DownloadSingleOperation.Install -> {
-            doInstall(operation.classes, operation.version, operation.versions)
-            changeOperation(DownloadSingleOperation.None)
+            LaunchedEffect(Unit) {
+                doInstall(operation.classes, operation.version, operation.versions)
+                changeOperation(DownloadSingleOperation.None)
+            }
         }
     }
 }


### PR DESCRIPTION
Close: #1698