### PR TITLE
feat: add official website link

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/path/UrlManager.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/path/UrlManager.kt
@@ -53,6 +53,7 @@ const val URL_MINECRAFT_VERSION_REPOS: String = "https://piston-meta.mojang.com/
 const val URL_MINECRAFT_ASSETS_INDEX: String = "https://launchermeta.mojang.com/v1/packages"
 const val URL_MINECRAFT_PURCHASE = "https://www.xbox.com/games/store/minecraft-java-bedrock-edition-for-pc/9nxp44l49shj"
 const val URL_PROJECT: String = "https://github.com/ZalithLauncher/ZalithLauncher2"
+const val URL_OFFICIAL_WEBSITE: String = "https://www.zalithlauncher.cn"
 const val URL_PROJECT_INFO: String = "https://api.github.com/repos/ZalithLauncher/Zalith-Info/contents/v2"
 const val URL_COMMUNITY: String = "https://github.com/ZalithLauncher/ZalithLauncher2/graphs/contributors"
 const val URL_WEBLATE: String = "https://hosted.weblate.org/projects/zalithlauncher2"

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/settings/AboutInfoScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/settings/AboutInfoScreen.kt
@@ -64,6 +64,7 @@ import com.movtery.zalithlauncher.library.LibraryInfo
 import com.movtery.zalithlauncher.library.libraryData
 import com.movtery.zalithlauncher.path.URL_COMMUNITY
 import com.movtery.zalithlauncher.path.URL_MCMOD
+import com.movtery.zalithlauncher.path.URL_OFFICIAL_WEBSITE
 import com.movtery.zalithlauncher.path.URL_PROJECT
 import com.movtery.zalithlauncher.path.URL_SUPPORT
 import com.movtery.zalithlauncher.path.URL_WEBLATE
@@ -116,6 +117,11 @@ fun AboutInfoScreen(
                                     onClick = { openLink(URL_PROJECT) }
                                 ) {
                                     Text(text = stringResource(R.string.about_launcher_project_link))
+                                }
+                                Button(
+                                    onClick = { openLink(URL_OFFICIAL_WEBSITE) }
+                                ) {
+                                    Text(text = stringResource(R.string.about_launcher_official_website))
                                 }
                             }
                         )

--- a/ZalithLauncher/src/main/res/values-zh-rCN/strings.xml
+++ b/ZalithLauncher/src/main/res/values-zh-rCN/strings.xml
@@ -1237,6 +1237,7 @@
     <string name="about_launcher_author_movtery_title">墨北MovTery</string>
     <string name="about_launcher_author_movtery_text">%s 的作者</string>
     <string name="about_launcher_project_link">项目地址</string>
+    <string name="about_launcher_official_website">官网地址</string>
     <string name="about_sponsor">赞助支持</string>
     <string name="about_acknowledgements_title">鸣谢</string>
     <string name="about_acknowledgements_pojav_text">%s 使用了 PojavLauncher 的启动后端</string>

--- a/ZalithLauncher/src/main/res/values/strings.xml
+++ b/ZalithLauncher/src/main/res/values/strings.xml
@@ -1237,6 +1237,7 @@
     <string name="about_launcher_author_movtery_title">MovTery</string>
     <string name="about_launcher_author_movtery_text">Author of %s</string>
     <string name="about_launcher_project_link">Project Link</string>
+    <string name="about_launcher_official_website">Official Website</string>
     <string name="about_sponsor">Sponsorship Support</string>
     <string name="about_acknowledgements_title">Acknowledgements</string>
     <string name="about_acknowledgements_pojav_text">%s uses the launch backend from PojavLauncher</string>


### PR DESCRIPTION
## Summary

- add an official website button next to the project link on the About page
- open https://www.zalithlauncher.cn from the new button
- add English and Simplified Chinese strings

## Testing

- Build verified locally: `./gradlew ZalithLauncher:assembleDebug -Darch=x86_64` passed.

> Re-submission of #1667 (the previous PR pointed at a branch without the commit and was closed).