### PR TITLE
修正渲染器版本适配情况

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/FreedrenoRenderer.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/FreedrenoRenderer.kt
@@ -29,7 +29,7 @@ object FreedrenoRenderer : RendererInterface {
 
     override fun getMaxMCVersion(): String = "26.3-snapshot-4"
 
-    override fun getDisplayMaxMCVersion(): String = "26.3"
+    override fun getDisplayMaxMCVersion(): String = "26.2"
 
     override fun getRendererEnv(): Lazy<Map<String, String>> = lazy { emptyMap() }
 

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/KopperZinkRenderer.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/KopperZinkRenderer.kt
@@ -29,7 +29,7 @@ object KopperZinkRenderer : RendererInterface {
 
     override fun getMaxMCVersion(): String = "26.3-snapshot-4"
 
-    override fun getDisplayMaxMCVersion(): String = "26.3"
+    override fun getDisplayMaxMCVersion(): String = "26.2"
 
     override fun getRendererEnv(): Lazy<Map<String, String>> = lazy {
         mapOf(

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/NGGL4ESRenderer.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/NGGL4ESRenderer.kt
@@ -29,7 +29,7 @@ object NGGL4ESRenderer : RendererInterface {
 
     override fun getMaxMCVersion(): String = "26.3-snapshot-4"
 
-    override fun getDisplayMaxMCVersion(): String = "26.3"
+    override fun getDisplayMaxMCVersion(): String = "26.2"
 
     override fun getRendererEnv(): Lazy<Map<String, String>> = lazy {
         buildMap {

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/VirGLRenderer.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/renderer/renderers/VirGLRenderer.kt
@@ -31,7 +31,7 @@ object VirGLRenderer : RendererInterface {
 
     override fun getMaxMCVersion(): String = "26.3-snapshot-4"
 
-    override fun getDisplayMaxMCVersion(): String = "26.3"
+    override fun getDisplayMaxMCVersion(): String = "26.2"
 
     override fun getRendererEnv(): Lazy<Map<String, String>> = lazy {
         mapOf(


### PR DESCRIPTION
误报几个快照不支持  应该比 误报一个正式版（和好几个快照）支持要好吧