### PR TITLE
feat: 下载资源时支持勾选并安装依赖项目

### DIFF
--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/_Download.Dependency.Tasks.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/_Download.Dependency.Tasks.kt
@@ -1,0 +1,492 @@
+/*
+ * Zalith Launcher 2
+ * Copyright (C) 2025 MovTery <movtery228@qq.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/gpl-3.0.txt>.
+ */
+
+package com.movtery.zalithlauncher.game.download.assets
+
+import com.movtery.zalithlauncher.R
+import com.movtery.zalithlauncher.coroutine.Task
+import com.movtery.zalithlauncher.coroutine.TaskSystem
+import com.movtery.zalithlauncher.game.addons.modloader.ModLoader
+import com.movtery.zalithlauncher.game.download.assets.platform.Platform
+import com.movtery.zalithlauncher.game.download.assets.platform.PlatformClasses
+import com.movtery.zalithlauncher.game.download.assets.platform.PlatformDependencyType
+import com.movtery.zalithlauncher.game.download.assets.platform.PlatformDisplayLabel
+import com.movtery.zalithlauncher.game.download.assets.platform.PlatformProject
+import com.movtery.zalithlauncher.game.download.assets.platform.PlatformVersion
+import com.movtery.zalithlauncher.game.download.assets.platform.curseforge.models.CurseForgeModLoader
+import com.movtery.zalithlauncher.game.download.assets.platform.getProjectByVersion
+import com.movtery.zalithlauncher.game.download.assets.platform.getVersionById
+import com.movtery.zalithlauncher.game.download.assets.platform.getVersions
+import com.movtery.zalithlauncher.game.download.assets.platform.modrinth.models.ModrinthModLoaderCategory
+import com.movtery.zalithlauncher.game.version.installed.Version
+import com.movtery.zalithlauncher.game.version.installed.VersionFolders
+import com.movtery.zalithlauncher.game.version.mod.matchInstalledMods
+import com.movtery.zalithlauncher.game.version.mod.scanModFingerprints
+import com.movtery.zalithlauncher.ui.androidText
+import com.movtery.zalithlauncher.ui.screens.content.download.assets.elements.initAll
+import com.movtery.zalithlauncher.utils.logging.Logger
+import com.movtery.zalithlauncher.viewmodel.ErrorViewModel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+private const val TAG = "DownloadDependency"
+
+/** 同一次依赖安装中允许处理的依赖项目数量上限，防止异常元数据导致依赖爆炸 */
+private const val MAX_DEPENDENCY_PROJECTS = 64
+
+/** 同时解析的依赖项目数量上限 */
+private const val DEPENDENCY_PARALLELISM = 4
+
+/**
+ * 需要一并安装的依赖项
+ * @param projectId 依赖项目在平台上的Id
+ * @param versionId 依赖的精确版本Id，为null则代表只指定了依赖项目
+ * @param classes 依赖资源的类别，决定其安装目录
+ * @param projectTitle 依赖项目标题，用于提示信息
+ */
+class DependencyRequest(
+    val platform: Platform,
+    val projectId: String,
+    val versionId: String?,
+    val classes: PlatformClasses,
+    val projectTitle: String
+)
+
+/**
+ * 为给定的游戏版本安装选中的依赖项，并递归展开它们标注的必装依赖
+ * @param requests 需要安装的依赖项
+ * @param versions 依赖项的目标游戏版本
+ */
+fun downloadDependenciesForVersions(
+    requests: List<DependencyRequest>,
+    versions: List<Version>,
+    submitError: (ErrorViewModel.ThrowableMessage) -> Unit
+) {
+    if (requests.isEmpty() || versions.isEmpty()) return
+
+    // 整理唯一任务id
+    val distinctRequests = requests.distinctBy { "${it.platform.name}/${it.projectId}/${it.versionId.orEmpty()}" }
+    val taskId = distinctRequests
+        .map { "${it.projectId}@${it.versionId.orEmpty()}" }
+        .sorted()
+        .joinToString(",")
+        .hashCode()
+
+    TaskSystem.submitTask(
+        Task.runTask(
+            id = "dependency/${distinctRequests.first().platform.name}/$taskId",
+            task = { task ->
+                task.updateMessage(
+                    androidText(R.string.download_assets_loading_dep_project, distinctRequests.first().projectId)
+                )
+
+                val context = DependencyContext(
+                    task = task,
+                    semaphore = Semaphore(DEPENDENCY_PARALLELISM),
+                    processed = ConcurrentHashMap<String, MutableSet<String>>(),
+                    projectCache = ConcurrentHashMap<String, PlatformProject>(),
+                    budget = AtomicInteger(MAX_DEPENDENCY_PROJECTS),
+                    downloadGroups = ConcurrentHashMap<String, DownloadGroup>(),
+                    failures = DependencyFailures()
+                )
+
+                coroutineScope {
+                    distinctRequests.forEach { request ->
+                        async { expand(request, versions, context) }
+                    }
+                }
+
+                context.publishDownloads(submitError)
+                context.failures.submit(submitError)
+            }
+        )
+    )
+}
+
+/**
+ * 统一展开依赖图时的共享上下文
+ */
+private class DependencyContext(
+    val task: Task,
+    val semaphore: Semaphore,
+    /** 依赖项目已处理过的目标游戏版本，键为项目键 */
+    val processed: ConcurrentHashMap<String, MutableSet<String>>,
+    /** 依赖项目信息缓存，避免重复查询 */
+    val projectCache: ConcurrentHashMap<String, PlatformProject>,
+    /** 剩余可处理的依赖项目数量 */
+    val budget: AtomicInteger,
+    /** 已解析出的下载分组，键为平台版本键 */
+    val downloadGroups: ConcurrentHashMap<String, DownloadGroup>,
+    val failures: DependencyFailures
+) {
+    /** 目标游戏版本对应的本地已安装模组项目集合 */
+    val installedMemo = ConcurrentHashMap<String, Set<String>>()
+    val installedMutex = Mutex()
+
+    /**
+     * 认领依赖项目尚未处理过的目标游戏版本
+     * @return 尚未处理过的目标游戏版本，为空则表示该项目无需继续处理
+     */
+    fun claimTargets(key: String, targets: List<Version>): List<Version> {
+        val claimed = processed[key] ?: run {
+            if (budget.getAndDecrement() <= 0) {
+                Logger.warning(TAG, "The dependency limit of $MAX_DEPENDENCY_PROJECTS has been reached, stopping the expansion.")
+                return emptyList()
+            }
+            processed.computeIfAbsent(key) { ConcurrentHashMap.newKeySet() }
+        }
+        return targets.filter { claimed.add(it.getVersionName()) }
+    }
+}
+
+/**
+ * 一并下载的依赖版本及其目标游戏版本
+ * @param folder 安装到游戏目录下的相对路径
+ */
+private class DownloadGroup(
+    val version: PlatformVersion,
+    val folder: String
+) {
+    private val targets = mutableListOf<Version>()
+
+    fun addTargets(versions: List<Version>) = synchronized(targets) {
+        versions.forEach { if (it !in targets) targets.add(it) }
+    }
+
+    fun targetList(): List<Version> = synchronized(targets) { targets.toList() }
+}
+
+/**
+ * 依赖失败信息，键为项目标题，值为未找到适配版本的目标游戏版本名
+ */
+private class DependencyFailures {
+    private val byProject = ConcurrentHashMap<String, MutableList<String>>()
+
+    fun record(title: String, versionName: String) {
+        val names = byProject.computeIfAbsent(title) { mutableListOf() }
+        synchronized(names) {
+            if (!names.contains(versionName)) names.add(versionName)
+        }
+    }
+
+    fun submit(submitError: (ErrorViewModel.ThrowableMessage) -> Unit) {
+        val snapshot = byProject.mapValues { it.value.toList() }.toSortedMap()
+        if (snapshot.isEmpty()) return
+
+        snapshot.forEach { (title, versionNames) ->
+            Logger.warning(TAG, "No compatible version found for the dependency: $title, ${versionNames.joinToString()}")
+        }
+
+        val texts = snapshot.keys.flatMapIndexed { index, title ->
+            buildList {
+                if (index > 0) add(androidText("\n"))
+                add(androidText(R.string.download_assets_dependency_no_compatible_version, title))
+            }
+        }
+        submitError(
+            ErrorViewModel.ThrowableMessage(
+                title = androidText(R.string.download_assets_install_failed),
+                message = androidText(*texts.toTypedArray())
+            )
+        )
+    }
+}
+
+private fun projectKey(
+    platform: Platform,
+    projectId: String
+): String = "${platform.name}/$projectId"
+
+/**
+ * 执行依赖解析操作，失败时写日志并返回null
+ */
+private suspend fun <T> resolveOrNull(
+    description: String,
+    block: suspend () -> T
+): T? {
+    return try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Logger.warning(TAG, description, e)
+        null
+    }
+}
+
+/**
+ * 展开一个依赖项
+ * 解析出具体版本、登记下载任务，并递归展开该版本的必装依赖
+ */
+private suspend fun expand(
+    request: DependencyRequest,
+    targets: List<Version>,
+    context: DependencyContext
+) {
+    // 只处理该项目尚未处理过的目标游戏版本，既避免重复处理，也能阻断依赖成环
+    val pendingTargets = context.claimTargets(projectKey(request.platform, request.projectId), targets)
+    if (pendingTargets.isEmpty()) return
+
+    try {
+        val folder = request.classes.versionFolder
+        if (folder == VersionFolders.NONE) {
+            // 无法确定依赖的安装目录
+            pendingTargets.forEach {
+                context.failures.record(request.projectTitle, it.getVersionName())
+            }
+            return
+        }
+
+        // 仅模组类型依赖会跳过本地已安装的目标游戏版本，已安装的依赖不再展开其依赖
+        val installTargets = if (request.classes == PlatformClasses.MOD) {
+            pendingTargets.filterNot { context.isInstalled(request, it) }
+        } else {
+            pendingTargets
+        }
+        if (installTargets.isEmpty()) return
+
+        val resolved = context.semaphore.withPermit {
+            context.resolve(request, installTargets)
+        }
+        resolved.forEach { (version, group) ->
+            context.registerDownload(request, version, group)
+        }
+
+        // 递归展开已解析版本的必装依赖
+        // 信号量只在解析期间持有，进入子树前已释放，避免递归等待许可造成死锁
+        resolved.forEach { (version, group) ->
+            val dependencies = resolveOrNull("Failed to read the dependencies of: ${request.projectTitle}") {
+                version.platformDependencies()
+            } ?: return@forEach
+            val required = dependencies.filter { it.type == PlatformDependencyType.REQUIRED }
+            if (required.isEmpty()) return@forEach
+
+            coroutineScope {
+                required.forEach { dependency ->
+                    val child = context.expandChild(dependency, request) ?: return@forEach
+                    async { expand(child, group, context) }
+                }
+            }
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Logger.warning(TAG, "An error occurred while installing the dependency: ${request.projectTitle}", e)
+        pendingTargets.forEach {
+            context.failures.record(request.projectTitle, it.getVersionName())
+        }
+    }
+}
+
+/**
+ * 解析依赖项在目标游戏版本上的具体版本
+ * @return 各具体版本与其对应的目标游戏版本
+ */
+private suspend fun DependencyContext.resolve(
+    request: DependencyRequest,
+    targets: List<Version>
+): List<Pair<PlatformVersion, List<Version>>> {
+    task.updateMessage(
+        androidText(R.string.download_assets_loading_dep_project, request.projectId)
+    )
+
+    if (request.versionId != null) {
+        // 主资源指定了依赖的精确版本，直接下载该版本
+        val version = resolveOrNull("Failed to retrieve the dependency version: ${request.versionId}") {
+            getVersionById(
+                versionId = request.versionId,
+                platform = request.platform,
+                printLog = false
+            )
+        }
+        if (version == null || !version.initFile(request.projectId)) {
+            targets.forEach {
+                failures.record(request.projectTitle, it.getVersionName())
+            }
+            return emptyList()
+        }
+        return listOf(version to targets)
+    }
+
+    // 拉取依赖项目的全部版本，再按各个目标游戏版本本地挑选
+    // initAll 已按发布时间倒序排列，取第一个适配的即为最新的版本
+    val allVersions = resolveOrNull("Failed to retrieve the dependency versions: ${request.projectId}") {
+        getVersions(
+            projectID = request.projectId,
+            platform = request.platform
+        ).initAll(request.projectId)
+    }
+    if (allVersions == null) {
+        targets.forEach {
+            failures.record(request.projectTitle, it.getVersionName())
+        }
+        return emptyList()
+    }
+
+    return targets
+        .groupBy { target -> allVersions.firstOrNull { it.isCompatibleWith(target, request.classes) } }
+        .mapNotNull { (version, group) ->
+            if (version == null) {
+                group.forEach {
+                    failures.record(request.projectTitle, it.getVersionName())
+                }
+                null
+            } else {
+                version to group
+            }
+        }
+}
+
+/**
+ * 将发现的传递依赖转换为可安装的依赖项
+ * 同一个项目在整张依赖图中只会被处理一次
+ */
+private suspend fun DependencyContext.expandChild(
+    dependency: PlatformVersion.PlatformDependency,
+    parent: DependencyRequest
+): DependencyRequest? = semaphore.withPermit {
+    val projectId = dependency.projectId ?: run {
+        val versionId = dependency.versionId ?: return@withPermit null
+        resolveOrNull("Failed to resolve the project of the dependency version: $versionId") {
+            getVersionById(versionId, dependency.platform, printLog = false).platformProjectId()
+        } ?: return@withPermit null
+    }
+
+    val (classes, title) = resolveProject(dependency.platform, projectId, parent.classes)
+    if (classes.versionFolder == VersionFolders.NONE) return@withPermit null
+
+    DependencyRequest(
+        platform = dependency.platform,
+        projectId = projectId,
+        versionId = dependency.versionId,
+        classes = classes,
+        projectTitle = title
+    )
+}
+
+/**
+ * 获取依赖项目的类别与标题
+ * 查询失败时回退到父依赖的类别，类别只影响安装目录，不应中断整条依赖链
+ */
+private suspend fun DependencyContext.resolveProject(
+    platform: Platform,
+    projectId: String,
+    fallbackClasses: PlatformClasses
+): Pair<PlatformClasses, String> {
+    projectCache[projectId]?.let { project ->
+        return project.platformClasses(fallbackClasses) to project.platformTitle()
+    }
+
+    val project = resolveOrNull("Failed to retrieve the dependency project information: $projectId") {
+        getProjectByVersion(projectId, platform, printLog = false)
+    } ?: return fallbackClasses to projectId
+
+    projectCache[projectId] = project
+    return project.platformClasses(fallbackClasses) to project.platformTitle()
+}
+
+private fun DependencyContext.registerDownload(
+    request: DependencyRequest,
+    version: PlatformVersion,
+    targets: List<Version>
+) {
+    val key = "${version.platform().name}/${version.platformId()}"
+    downloadGroups.computeIfAbsent(key) {
+        DownloadGroup(version, request.classes.versionFolder.folderName)
+    }.addTargets(targets)
+}
+
+/**
+ * 依赖图展开完成后，统一发布下载任务
+ */
+private fun DependencyContext.publishDownloads(
+    submitError: (ErrorViewModel.ThrowableMessage) -> Unit
+) {
+    downloadGroups.toSortedMap().values.forEach { group ->
+        val targets = group.targetList()
+        if (targets.isEmpty()) return@forEach
+        downloadSingleForVersions(
+            version = group.version,
+            versions = targets,
+            folder = group.folder,
+            submitError = submitError
+        )
+    }
+}
+
+/**
+ * 目标游戏版本的模组目录中是否已安装该依赖项目
+ * 检查失败时按未安装处理，避免漏装
+ */
+private suspend fun DependencyContext.isInstalled(
+    request: DependencyRequest,
+    target: Version
+): Boolean {
+    val key = "${request.platform.name}/${target.getVersionName()}"
+    installedMemo[key]?.let { return request.projectId in it }
+
+    val projects = installedMutex.withLock {
+        installedMemo[key] ?: resolveOrNull("Failed to check whether the dependency is installed locally: ${request.projectTitle}") {
+            val modsDir = VersionFolders.MOD.getDir(target.getGameDir())
+            matchInstalledMods(
+                fingerprints = scanModFingerprints(modsDir),
+                platform = request.platform
+            ).byProject.keys.toSet()
+        }?.also { installedMemo[key] = it }
+    }
+    return projects?.contains(request.projectId) == true
+}
+
+/**
+ * 该依赖版本是否适配目标游戏版本
+ */
+private fun PlatformVersion.isCompatibleWith(
+    target: Version,
+    classes: PlatformClasses
+): Boolean {
+    val info = target.getVersionInfo() ?: return true
+    if (info.minecraftVersion !in platformGameVersion()) return false
+
+    // 仅模组依赖需要校验模组加载器
+    if (classes != PlatformClasses.MOD) return true
+    val targetLoader = info.loaderInfo?.loader?.toPlatformLoader(platform()) ?: return true
+    val versionLoaders = platformLoaders()
+    return versionLoaders.isEmpty() || targetLoader in versionLoaders
+}
+
+/**
+ * 将本地模组加载器转换为平台上的加载器标识
+ */
+private fun ModLoader.toPlatformLoader(platform: Platform): PlatformDisplayLabel? {
+    if (displayName.isEmpty()) return null
+    return when (platform) {
+        Platform.MODRINTH -> ModrinthModLoaderCategory.entries.find {
+            it.getDisplayName().equals(displayName, true)
+        }
+        Platform.CURSEFORGE -> CurseForgeModLoader.entries.find {
+            it.getDisplayName().equals(displayName, true)
+        }
+    }
+}

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/_Download.Single.Tasks.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/_Download.Single.Tasks.kt
@@ -61,10 +61,12 @@ fun downloadSingleForVersions(
     onFileCancelled: (zip: File, folder: File) -> Unit = { _, _ -> },
     submitError: (ErrorViewModel.ThrowableMessage) -> Unit
 ) {
-    val cacheFile = File(File(PathManager.DIR_CACHE, "assets"), version.platformSha1() ?: version.platformFileName())
+    val fileKey = version.platformSha1() ?: version.platformFileName()
+    val cacheFile = File(File(PathManager.DIR_CACHE, "assets"), fileKey)
 
     downloadSingleFile(
         version = version,
+        taskId = downloadTaskId(fileKey, versions),
         file = cacheFile,
         onDownloaded = { task ->
             task.updateProgress(-1f)
@@ -103,8 +105,18 @@ fun downloadSingleForVersions(
     )
 }
 
+/**
+ * 下载任务的Id
+ * 同一文件安装到不同的游戏版本时属于不同的任务，避免被误判为重复任务而丢弃目标版本
+ */
+private fun downloadTaskId(fileKey: String, versions: List<Version>): String {
+    if (versions.isEmpty()) return fileKey
+    return "$fileKey|${versions.map { it.getVersionName() }.sorted().joinToString(",")}"
+}
+
 private fun downloadSingleFile(
     version: PlatformVersion,
+    taskId: String,
     file: File,
     onDownloaded: suspend (Task) -> Unit,
     onError: (Throwable) -> Unit = {},
@@ -113,7 +125,7 @@ private fun downloadSingleFile(
 ) {
     TaskSystem.submitTask(
         Task.runTask(
-            id = version.platformSha1() ?: version.platformFileName(),
+            id = taskId,
             task = { task ->
                 val totalFileSize = version.platformFileSize()
                 var downloadedSize = 0L

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/PlatformVersion.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/PlatformVersion.kt
@@ -42,6 +42,11 @@ interface PlatformVersion {
     fun platformId(): String
 
     /**
+     * 该版本在平台上所属的项目Id
+     */
+    fun platformProjectId(): String
+
+    /**
      * 该版本在平台上的显示名称
      */
     fun platformDisplayName(): String
@@ -103,11 +108,21 @@ interface PlatformVersion {
 
     /**
      * 平台版本依赖项目类，保存依赖项关键信息
+     * @param projectId 依赖项目Id，若平台只提供了精确版本Id，则该值为null
+     * @param versionId 依赖的精确版本Id，为null则代表只指定了依赖项目
      * @param type 依赖类型
      */
     class PlatformDependency(
         val platform: Platform,
-        val projectId: String,
+        val projectId: String?,
+        val versionId: String? = null,
         val type: PlatformDependencyType
     )
+}
+
+/**
+ * 依赖项在缓存与去重时使用的键
+ */
+fun PlatformVersion.PlatformDependency.cacheKey(): String {
+    return "${platform.name}/${projectId.orEmpty()}/${versionId.orEmpty()}"
 }

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/_PlatformSearch.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/_PlatformSearch.kt
@@ -304,6 +304,26 @@ suspend fun getProjectByVersion(
     }
 }
 
+/**
+ * 获取指定平台上的单个版本
+ * @param versionId 版本在平台上的Id
+ */
+suspend fun getVersionById(
+    versionId: String,
+    platform: Platform,
+    printLog: Boolean = true
+): PlatformVersion = withContext(Dispatchers.IO) {
+    when (platform) {
+        Platform.MODRINTH -> mirroredPlatformSearcher(
+            searchers = mirroredModrinthSource(),
+            printLog = printLog
+        ) { searcher ->
+            searcher.getVersion(versionId)
+        }
+        Platform.CURSEFORGE -> error("CurseForge dependencies do not carry a version id.")
+    }
+}
+
 suspend fun getVersionByLocalFile(file: File, sha1: String): PlatformVersion? = withContext(Dispatchers.IO) {
     coroutineScope {
         val modrinthDeferred = async(Dispatchers.IO) {

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/curseforge/models/CurseForgeFile.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/curseforge/models/CurseForgeFile.kt
@@ -272,6 +272,8 @@ class CurseForgeFile(
 
     override fun platformId(): String = id.toString()
 
+    override fun platformProjectId(): String = modId.toString()
+
     override fun platformDisplayName(): String = thisPrimaryFile.displayName
 
     override fun platformFileName(): String = thisPrimaryFile.fileName!!

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/modrinth/ModrinthSearcher.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/modrinth/ModrinthSearcher.kt
@@ -93,6 +93,15 @@ class ModrinthSearcher(
         )
     }
 
+    /**
+     * 获取 Modrinth 指定Id的单个版本
+     */
+    suspend fun getVersion(versionID: String): ModrinthVersion {
+        return httpGetJson(
+            url = "$api/version/$versionID"
+        )
+    }
+
     override suspend fun getVersionByLocalFile(
         file: File,
         sha1: String

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/modrinth/models/ModrinthVersion.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/download/assets/platform/modrinth/models/ModrinthVersion.kt
@@ -139,6 +139,8 @@ class ModrinthVersion(
 
     override fun platformId(): String = id
 
+    override fun platformProjectId(): String = projectId
+
     override fun platformDisplayName(): String = name
 
     override fun platformFileName(): String = thisPrimaryFile.fileName
@@ -154,10 +156,11 @@ class ModrinthVersion(
     override fun platformReleaseType(): PlatformReleaseType = versionType
 
     override fun platformDependencies(): List<PlatformVersion.PlatformDependency> = dependencies.mapNotNull { dependency ->
+        if (dependency.projectId == null && dependency.versionId == null) return@mapNotNull null
         PlatformVersion.PlatformDependency(
             platform = platform(),
-            //若未提供项目Id，则判定其无效或被删除，跳过该依赖
-            projectId = dependency.projectId ?: return@mapNotNull null,
+            projectId = dependency.projectId,
+            versionId = dependency.versionId,
             type = dependency.dependencyType
         )
     }

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/version/mod/InstalledModMatcher.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/game/version/mod/InstalledModMatcher.kt
@@ -1,0 +1,168 @@
+/*
+ * Zalith Launcher 2
+ * Copyright (C) 2025 MovTery <movtery228@qq.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/gpl-3.0.txt>.
+ */
+
+package com.movtery.zalithlauncher.game.version.mod
+
+import com.movtery.zalithlauncher.game.download.assets.platform.FINGERPRINT_BATCH_SIZE
+import com.movtery.zalithlauncher.game.download.assets.platform.Platform
+import com.movtery.zalithlauncher.game.download.assets.platform.getCFFilesByFingerprints
+import com.movtery.zalithlauncher.game.download.assets.platform.getModrinthVersBySha1
+import com.movtery.zalithlauncher.utils.logging.Logger
+import com.tencent.mmkv.MMKV
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import java.io.File
+
+private const val TAG = "InstalledModMatcher"
+
+/**
+ * 本地模组指纹的平台匹配结果
+ * @param byProject 以平台项目Id为键
+ * @param byVersion 以平台版本Id为键
+ * @param complete 是否所有指纹分块都匹配成功，存在失败分块时部分指纹未匹配
+ */
+class MatchedInstalledMods(
+    val byProject: Map<String, InstalledMod>,
+    val byVersion: Map<String, InstalledMod>,
+    val complete: Boolean
+)
+
+/**
+ * 并发计算模组目录内所有文件的指纹
+ */
+suspend fun scanModFingerprints(modsDir: File): List<ModFingerprints> =
+    withContext(Dispatchers.IO) {
+        val files = modsDir.listFiles()
+            ?.filter { it.isFile && it.isModFileCandidate() }
+            ?: return@withContext emptyList()
+
+        val semaphore = Semaphore(READER_PARALLELISM)
+        coroutineScope {
+            files.map { file ->
+                async {
+                    semaphore.withPermit {
+                        runCatching {
+                            computeModFingerprints(file)
+                        }.onFailure { e ->
+                            Logger.warning(TAG, "Failed to compute mod fingerprints: ${file.name}", e)
+                        }.getOrNull()
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+    }
+
+/**
+ * 将本地模组指纹与指定平台匹配，得到本地已安装的模组信息
+ * 优先读取持久缓存，只对未命中的指纹发起批量查询
+ */
+suspend fun matchInstalledMods(
+    fingerprints: List<ModFingerprints>,
+    platform: Platform
+): MatchedInstalledMods {
+    val byProject = mutableMapOf<String, InstalledMod>()
+    val byVersion = mutableMapOf<String, InstalledMod>()
+    if (fingerprints.isEmpty()) {
+        return MatchedInstalledMods(byProject, byVersion, complete = true)
+    }
+
+    var complete = true
+
+    fun collect(installed: InstalledMod) {
+        if (installed.notFound) return
+        byProject[installed.projectId] = installed
+        byVersion[installed.versionId] = installed
+    }
+
+    val cache = installedModCache()
+    val uncached = mutableListOf<ModFingerprints>()
+    for (print in fingerprints) {
+        val cached = cache.decodeParcelable(print.cacheKey(platform), InstalledMod::class.java)
+        if (cached != null) collect(cached) else uncached.add(print)
+    }
+
+    // 分块批量查询，块内成功时才允许写入持久缓存（含未命中的负缓存），
+    // 失败的块不写任何缓存，留待下次重试
+    for (chunk in uncached.chunked(FINGERPRINT_BATCH_SIZE)) {
+        runCatching {
+            when (platform) {
+                Platform.MODRINTH -> getModrinthVersBySha1(chunk.map { it.sha1 })
+                Platform.CURSEFORGE ->
+                    getCFFilesByFingerprints(chunk.map { it.murmur2 }).mapKeys { it.key.toString() }
+            }
+        }.onSuccess { fetched ->
+            for (print in chunk) {
+                val installed = fetched[print.fingerprintValue(platform)]?.toInstalledMod() ?: notFoundMod(platform)
+                cache.encode(print.cacheKey(platform), installed, MMKV.ExpireInDay)
+                collect(installed)
+            }
+        }.onFailure { e ->
+            complete = false
+            Logger.warning(TAG, "Failed to match installed mods on platform: $platform", e)
+        }
+    }
+
+    return MatchedInstalledMods(byProject, byVersion, complete)
+}
+
+/**
+ * 可能为模组的文件扩展名（.disabled 后缀的文件已去除后缀再判断）
+ */
+private val MOD_FILE_EXTENSIONS = setOf("jar", "zip", "litemod")
+
+/**
+ * 文件是否可能为模组文件，非模组文件不参与指纹计算
+ */
+private fun File.isModFileCandidate(): Boolean {
+    val extension = if (isDisabled()) {
+        File(nameWithoutExtension).extension
+    } else {
+        extension
+    }
+    return extension.lowercase() in MOD_FILE_EXTENSIONS
+}
+
+/**
+ * 指纹在持久缓存中的键，不同平台的指纹相互独立
+ */
+private fun ModFingerprints.cacheKey(platform: Platform): String =
+    "${platform.name}/${fingerprintValue(platform)}"
+
+/**
+ * 指纹在对应平台上的匹配键
+ */
+private fun ModFingerprints.fingerprintValue(platform: Platform): String = when (platform) {
+    Platform.MODRINTH -> sha1
+    Platform.CURSEFORGE -> murmur2.toString()
+}
+
+/**
+ * 平台未命中指纹时的负缓存标记
+ */
+private fun notFoundMod(platform: Platform): InstalledMod = InstalledMod(
+    platform = platform,
+    projectId = "",
+    versionId = "",
+    versionName = "",
+    notFound = true
+)

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/assetinfo/AssetInfoScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/assetinfo/AssetInfoScreen.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDe
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.movtery.zalithlauncher.game.download.assets.downloadDependenciesForVersions
 import com.movtery.zalithlauncher.game.download.assets.downloadSingleForVersions
 import com.movtery.zalithlauncher.ui.screens.NestedNavKey
 import com.movtery.zalithlauncher.ui.screens.NormalNavKey
@@ -69,17 +70,22 @@ fun AssetInfoScreen(
     DownloadSingleOperation(
         operation = operation,
         changeOperation = { operation = it },
-        doInstall = { classes, version, gameVersions ->
+        doInstall = { classes, version, gameVersions, dependencies ->
             downloadSingleForVersions(
                 version = version,
                 versions = gameVersions,
                 folder = classes.versionFolder.folderName,
                 submitError = submitError
             )
+            downloadDependenciesForVersions(
+                requests = dependencies,
+                versions = gameVersions,
+                submitError = submitError
+            )
         },
-        onDependencyClicked = { dep, classes ->
+        onDependencyClicked = { platform, projectId, classes ->
             backStack.navigateTo(
-                NormalNavKey.DownloadAssets(dep.platform, dep.projectId, classes)
+                NormalNavKey.DownloadAssets(platform, projectId, classes)
             )
         }
     )

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadModScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadModScreen.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDe
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.movtery.zalithlauncher.game.download.assets.downloadDependenciesForVersions
 import com.movtery.zalithlauncher.game.download.assets.downloadSingleForVersions
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformClasses
 import com.movtery.zalithlauncher.game.version.installed.VersionsManager
@@ -75,22 +76,34 @@ fun DownloadModScreen(
 
     val context = LocalContext.current
 
+    //当前版本本地已安装的模组项目，用于依赖项的已安装标注与默认勾选
+    val installedByProject = installedViewModel.installedByProject
+    val installedProjects = remember(installedByProject, installedViewModel.currentPlatform) {
+        mapOf(installedViewModel.currentPlatform to installedByProject.keys.toSet())
+    }
+
     //下载资源操作
     var operation by remember { mutableStateOf<DownloadSingleOperation>(DownloadSingleOperation.None) }
     DownloadSingleOperation(
         operation = operation,
         changeOperation = { operation = it },
-        doInstall = { classes, version, gameVersions ->
+        doInstall = { classes, version, gameVersions, dependencies ->
             downloadSingleForVersions(
                 version = version,
                 versions = gameVersions,
                 folder = classes.versionFolder.folderName,
                 submitError = submitError
             )
+            downloadDependenciesForVersions(
+                requests = dependencies,
+                versions = gameVersions,
+                submitError = submitError
+            )
         },
-        onDependencyClicked = { dep, classes ->
+        installedProjects = installedProjects,
+        onDependencyClicked = { platform, projectId, classes ->
             backStack.navigateTo(
-                NormalNavKey.DownloadAssets(dep.platform, dep.projectId, classes)
+                NormalNavKey.DownloadAssets(platform, projectId, classes)
             )
         }
     )

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadModViewModel.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadModViewModel.kt
@@ -23,33 +23,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.movtery.zalithlauncher.game.download.assets.platform.FINGERPRINT_BATCH_SIZE
 import com.movtery.zalithlauncher.game.download.assets.platform.Platform
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformVersion
-import com.movtery.zalithlauncher.game.download.assets.platform.getCFFilesByFingerprints
-import com.movtery.zalithlauncher.game.download.assets.platform.getModrinthVersBySha1
 import com.movtery.zalithlauncher.game.version.installed.Version
 import com.movtery.zalithlauncher.game.version.installed.VersionFolders
 import com.movtery.zalithlauncher.game.version.mod.InstalledMod
 import com.movtery.zalithlauncher.game.version.mod.ModFingerprints
-import com.movtery.zalithlauncher.game.version.mod.READER_PARALLELISM
-import com.movtery.zalithlauncher.game.version.mod.computeModFingerprints
-import com.movtery.zalithlauncher.game.version.mod.installedModCache
-import com.movtery.zalithlauncher.game.version.mod.isDisabled
-import com.movtery.zalithlauncher.game.version.mod.toInstalledMod
+import com.movtery.zalithlauncher.game.version.mod.matchInstalledMods
+import com.movtery.zalithlauncher.game.version.mod.scanModFingerprints
 import com.movtery.zalithlauncher.setting.AllSettings
 import com.movtery.zalithlauncher.utils.logging.Logger
-import com.tencent.mmkv.MMKV
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
-import kotlinx.coroutines.withContext
-import java.io.File
 
 private const val TAG = "DownloadModViewModel"
 
@@ -120,7 +105,7 @@ class DownloadModViewModel : ViewModel() {
             scannedVersionName = versionName
             scannedFingerprints = version?.let { ver ->
                 runCatching {
-                    scanFingerprints(VersionFolders.MOD.getDir(ver.getGameDir()))
+                    scanModFingerprints(VersionFolders.MOD.getDir(ver.getGameDir()))
                 }.onFailure { e ->
                     Logger.warning(TAG, "Failed to scan local mod fingerprints", e)
                 }.getOrDefault(emptyList())
@@ -162,121 +147,14 @@ class DownloadModViewModel : ViewModel() {
             return
         }
 
-        val cache = installedModCache()
-        val byProject = mutableMapOf<String, InstalledMod>()
-        val byVersion = mutableMapOf<String, InstalledMod>()
-        var allSucceeded = true
-
-        fun collect(installed: InstalledMod) {
-            if (installed.notFound) return
-            byProject[installed.projectId] = installed
-            byVersion[installed.versionId] = installed
-        }
-
-        // 优先读取持久缓存，只对未命中的指纹发起批量查询
-        val uncached = mutableListOf<ModFingerprints>()
-        for (print in fingerprints) {
-            val cached = cache.decodeParcelable(print.cacheKey(platform), InstalledMod::class.java)
-            if (cached != null) collect(cached) else uncached.add(print)
-        }
-
-        // 分块批量查询；块内成功时才允许写入持久缓存（含未命中的负缓存），
-        // 失败的块不写任何缓存，留待下次进入时重试
-        for (chunk in uncached.chunked(FINGERPRINT_BATCH_SIZE)) {
-            runCatching {
-                when (platform) {
-                    Platform.MODRINTH -> getModrinthVersBySha1(chunk.map { it.sha1 })
-                    Platform.CURSEFORGE ->
-                        getCFFilesByFingerprints(chunk.map { it.murmur2 }).mapKeys { it.key.toString() }
-                }
-            }.onSuccess { fetched ->
-                for (print in chunk) {
-                    val installed = fetched[print.fingerprintValue(platform)]?.toInstalledMod()
-                        ?: notFoundMod(platform)
-                    cache.encode(print.cacheKey(platform), installed, MMKV.ExpireInDay)
-                    collect(installed)
-                }
-            }.onFailure { e ->
-                allSucceeded = false
-                Logger.warning(TAG, "Failed to match installed mods on platform: $platform", e)
-            }
-        }
-
-        val result = byProject to byVersion
-        // 存在失败块时不做会话内缓存，下次切换平台时重试（成功块已有持久缓存兜底）
-        if (allSucceeded) matchedResults[platform] = result
-        installedByProject = result.first
-        installedByVersion = result.second
+        val matched = matchInstalledMods(fingerprints, platform)
+        // 存在失败分块时不做会话内缓存，下次切换平台时重试（成功块已有持久缓存兜底）
+        if (matched.complete) matchedResults[platform] = matched.byProject to matched.byVersion
+        installedByProject = matched.byProject
+        installedByVersion = matched.byVersion
     }
-
-    /**
-     * 并发计算模组目录内所有文件的指纹
-     */
-    private suspend fun scanFingerprints(modsDir: File): List<ModFingerprints> =
-        withContext(Dispatchers.IO) {
-            val files = modsDir.listFiles()
-                ?.filter { it.isFile && it.isModFileCandidate() }
-                ?: return@withContext emptyList()
-
-            val semaphore = Semaphore(READER_PARALLELISM)
-            coroutineScope {
-                files.map { file ->
-                    async {
-                        semaphore.withPermit {
-                            runCatching { computeModFingerprints(file) }
-                                .onFailure { e ->
-                                    Logger.warning(TAG, "Failed to compute mod fingerprints: ${file.name}", e)
-                                }
-                                .getOrNull()
-                        }
-                    }
-                }.awaitAll().filterNotNull()
-            }
-        }
 
     override fun onCleared() {
         scanJob?.cancel()
     }
 }
-
-/**
- * 可能为模组的文件扩展名（.disabled 后缀的文件已去除后缀再判断）
- */
-private val MOD_FILE_EXTENSIONS = setOf("jar", "zip", "litemod")
-
-/**
- * 文件是否可能为模组文件，非模组文件不参与指纹计算
- */
-private fun File.isModFileCandidate(): Boolean {
-    val extension = if (isDisabled()) {
-        File(nameWithoutExtension).extension
-    } else {
-        extension
-    }
-    return extension.lowercase() in MOD_FILE_EXTENSIONS
-}
-
-/**
- * 指纹在持久缓存中的键，不同平台的指纹相互独立
- */
-private fun ModFingerprints.cacheKey(platform: Platform): String =
-    "${platform.name}/${fingerprintValue(platform)}"
-
-/**
- * 指纹在对应平台上的匹配键
- */
-private fun ModFingerprints.fingerprintValue(platform: Platform): String = when (platform) {
-    Platform.MODRINTH -> sha1
-    Platform.CURSEFORGE -> murmur2.toString()
-}
-
-/**
- * 平台未命中指纹时的负缓存标记
- */
-private fun notFoundMod(platform: Platform): InstalledMod = InstalledMod(
-    platform = platform,
-    projectId = "",
-    versionId = "",
-    versionName = "",
-    notFound = true
-)

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadResourcePackScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadResourcePackScreen.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDe
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.movtery.zalithlauncher.game.download.assets.downloadDependenciesForVersions
 import com.movtery.zalithlauncher.game.download.assets.downloadSingleForVersions
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformClasses
 import com.movtery.zalithlauncher.ui.screens.NestedNavKey
@@ -70,17 +71,22 @@ fun DownloadResourcePackScreen(
     DownloadSingleOperation(
         operation = operation,
         changeOperation = { operation = it },
-        doInstall = { classes, version, versions ->
+        doInstall = { classes, version, versions, dependencies ->
             downloadSingleForVersions(
                 version = version,
                 versions = versions,
                 folder = classes.versionFolder.folderName,
                 submitError = submitError
             )
+            downloadDependenciesForVersions(
+                requests = dependencies,
+                versions = versions,
+                submitError = submitError
+            )
         },
-        onDependencyClicked = { dep, classes ->
+        onDependencyClicked = { platform, projectId, classes ->
             backStack.navigateTo(
-                NormalNavKey.DownloadAssets(dep.platform, dep.projectId, classes)
+                NormalNavKey.DownloadAssets(platform, projectId, classes)
             )
         }
     )

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadSavesScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadSavesScreen.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDe
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.movtery.zalithlauncher.game.download.assets.downloadDependenciesForVersions
 import com.movtery.zalithlauncher.game.download.assets.downloadSingleForVersions
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformClasses
 import com.movtery.zalithlauncher.game.version.saves.unpackSaveZip
@@ -76,7 +77,7 @@ fun DownloadSavesScreen(
     DownloadSingleOperation(
         operation = operation,
         changeOperation = { operation = it },
-        doInstall = { classes, version, versions ->
+        doInstall = { classes, version, versions, dependencies ->
             downloadSingleForVersions(
                 version = version,
                 versions = versions,
@@ -96,10 +97,15 @@ fun DownloadSavesScreen(
                 },
                 submitError = submitError
             )
+            downloadDependenciesForVersions(
+                requests = dependencies,
+                versions = versions,
+                submitError = submitError
+            )
         },
-        onDependencyClicked = { dep, classes ->
+        onDependencyClicked = { platform, projectId, classes ->
             backStack.navigateTo(
-                NormalNavKey.DownloadAssets(dep.platform, dep.projectId, classes)
+                NormalNavKey.DownloadAssets(platform, projectId, classes)
             )
         }
     )

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadShadersScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/DownloadShadersScreen.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDe
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.movtery.zalithlauncher.game.download.assets.downloadDependenciesForVersions
 import com.movtery.zalithlauncher.game.download.assets.downloadSingleForVersions
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformClasses
 import com.movtery.zalithlauncher.ui.screens.NestedNavKey
@@ -70,17 +71,22 @@ fun DownloadShadersScreen(
     DownloadSingleOperation(
         operation = operation,
         changeOperation = { operation = it },
-        doInstall = { classes, version, versions ->
+        doInstall = { classes, version, versions, dependencies ->
             downloadSingleForVersions(
                 version = version,
                 versions = versions,
                 folder = classes.versionFolder.folderName,
                 submitError = submitError
             )
+            downloadDependenciesForVersions(
+                requests = dependencies,
+                versions = versions,
+                submitError = submitError
+            )
         },
-        onDependencyClicked = { dep, classes ->
+        onDependencyClicked = { platform, projectId, classes ->
             backStack.navigateTo(
-                NormalNavKey.DownloadAssets(dep.platform, dep.projectId, classes)
+                NormalNavKey.DownloadAssets(platform, projectId, classes)
             )
         }
     )

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/download/DownloadAssetsScreen.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/download/DownloadAssetsScreen.kt
@@ -66,7 +66,9 @@ import com.movtery.zalithlauncher.game.download.assets.platform.Platform
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformClasses
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformProject
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformVersion
+import com.movtery.zalithlauncher.game.download.assets.platform.cacheKey
 import com.movtery.zalithlauncher.game.download.assets.platform.getProject
+import com.movtery.zalithlauncher.game.download.assets.platform.getVersionById
 import com.movtery.zalithlauncher.game.download.assets.platform.getVersions
 import com.movtery.zalithlauncher.game.download.assets.platform.isAllNull
 import com.movtery.zalithlauncher.game.download.assets.utils.ModTranslations
@@ -87,6 +89,7 @@ import com.movtery.zalithlauncher.ui.screens.NormalNavKey
 import com.movtery.zalithlauncher.ui.screens.TitledNavKey
 import com.movtery.zalithlauncher.ui.screens.content.download.assets.elements.AssetsIcon
 import com.movtery.zalithlauncher.ui.screens.content.download.assets.elements.AssetsVersionItemLayout
+import com.movtery.zalithlauncher.ui.screens.content.download.assets.elements.DependencyEntry
 import com.movtery.zalithlauncher.ui.screens.content.download.assets.elements.DownloadAssetsState
 import com.movtery.zalithlauncher.ui.screens.content.download.assets.elements.DownloadAssetsVersionLoading
 import com.movtery.zalithlauncher.ui.screens.content.download.assets.elements.ProjectUrlsContent
@@ -98,6 +101,7 @@ import com.movtery.zalithlauncher.ui.theme.onCardColor
 import com.movtery.zalithlauncher.utils.animation.swapAnimateDpAsState
 import com.movtery.zalithlauncher.viewmodel.EventViewModel
 import io.ktor.client.plugins.ClientRequestException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
@@ -117,8 +121,6 @@ private class DownloadScreenViewModel(
     var versionsResult by mutableStateOf<DownloadAssetsState<List<VersionInfoMap>>>(DownloadAssetsState.Getting())
     var versionsLoading by mutableStateOf<DownloadAssetsVersionLoading>(DownloadAssetsVersionLoading.None)
         private set
-    /** 当前正在加载的依赖项目 */
-    val loadingProjects = mutableStateListOf<String>()
 
     var showOnlyMCRelease by mutableStateOf(true)
     var searchMCVersion by mutableStateOf("")
@@ -146,6 +148,8 @@ private class DownloadScreenViewModel(
     fun getVersions() {
         viewModelScope.launch {
             versionsResult = DownloadAssetsState.Getting()
+            //重新加载时重试此前获取失败的依赖项目
+            failedDependencyProjects.clear()
             if (platform == Platform.CURSEFORGE) {
                 versionsLoading = DownloadAssetsVersionLoading.StartLoadPage
             }
@@ -157,39 +161,32 @@ private class DownloadScreenViewModel(
                     versionsLoading = DownloadAssetsVersionLoading.LoadingPage(chunk, page)
                 },
                 onSuccess = { result ->
-                    val versions: List<PlatformVersion> = result.initAll(projectId) also@{ version ->
-                        if (classes == PlatformClasses.MOD_PACK) return@also //整合包不支持获取依赖
-                        val dependencies = version.platformDependencies()
-                        if (dependencies.isEmpty()) return@also
+                    val versions: List<PlatformVersion> = result.initAll(projectId)
 
-                        loadingProjects.clear()
-                        versionsLoading = DownloadAssetsVersionLoading.LoadingDepProject
-
-                        val semaphore = Semaphore(8)
-                        val jobs = dependencies.map { dependency ->
-                            async {
-                                semaphore.withPermit {
-                                    cacheDependencyProject(
-                                        platform = version.platform(),
-                                        projectId = dependency.projectId,
-                                        onLoading = {
-                                            if (!loadingProjects.contains(dependency.projectId)) {
-                                                loadingProjects.add(dependency.projectId)
-                                            }
-                                        },
-                                        onEnd = {
-                                            loadingProjects.remove(dependency.projectId)
-                                        }
-                                    )
-                                }
-                            }
-                        }
-
-                        jobs.awaitAll()
-                    }
+                    //版本列表先行展示，依赖项目信息改为后台缓存，不再阻塞列表加载
                     _versionsList = versions.mapWithVersions(classes)
                     versionsResult = DownloadAssetsState.Success(_versionsList.filterInfos())
                     versionsLoading = DownloadAssetsVersionLoading.None
+
+                    if (classes == PlatformClasses.MOD_PACK) return@getVersions
+                    val dependencies = versions
+                        .flatMap { it.platformDependencies() }
+                        .distinctBy { it.cacheKey() }
+                    if (dependencies.isEmpty()) return@getVersions
+
+                    viewModelScope.launch {
+                        val semaphore = Semaphore(8)
+                        dependencies.map { dependency ->
+                            async {
+                                semaphore.withPermit {
+                                    cacheDependencyProject(
+                                        platform = dependency.platform,
+                                        dependency = dependency
+                                    )
+                                }
+                            }
+                        }.awaitAll()
+                    }
                 },
                 onError = {
                     versionsResult = it
@@ -226,35 +223,51 @@ private class DownloadScreenViewModel(
     //就会进行很多次无效的访问，非常耗时
     //需要记录不存在的依赖项目的id，避免下次继续获取
     val notFoundDependencyProjects = mutableStateListOf<String>()
+    //依赖项目信息获取失败，在对话框里展示占位项
+    val failedDependencyProjects = mutableStateListOf<String>()
 
     /**
      * 缓存依赖项目
      */
     private suspend fun cacheDependencyProject(
         platform: Platform,
-        projectId: String,
-        onLoading: () -> Unit,
-        onEnd: () -> Unit
+        dependency: PlatformVersion.PlatformDependency
     ) {
-        if (!notFoundDependencyProjects.contains(projectId) && !cachedDependencyProject.containsKey(projectId)) {
-            onLoading()
+        val key = dependency.cacheKey()
+        if (notFoundDependencyProjects.contains(key) || cachedDependencyProject.containsKey(key)) return
+
+        try {
+            val projectId = dependency.projectId ?: run {
+                //依赖只标注了精确版本，先通过版本反查其所属项目
+                getVersionById(
+                    versionId = dependency.versionId
+                        ?: error("The dependency does not provide a project id or a version id."),
+                    platform = platform,
+                    printLog = false
+                ).platformProjectId()
+            }
             getProject<PlatformProject>(
                 projectID = projectId,
                 platform = platform,
                 onSuccess = { result ->
-                    cachedDependencyProject[projectId] = result
-                    onEnd()
+                    cachedDependencyProject[key] = result
                 },
                 onError = { _, e ->
-                    if (e is ClientRequestException && e.response.status.value == 404) {
-                        // 404 Not Found
-                        notFoundDependencyProjects.add(projectId)
+                    if (e.isNotFound()) {
+                        notFoundDependencyProjects.add(key)
                     } else {
-                        cachedDependencyProject.remove(projectId)
+                        if (!failedDependencyProjects.contains(key)) failedDependencyProjects.add(key)
                     }
-                    onEnd()
                 }
             )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            if (e.isNotFound()) {
+                notFoundDependencyProjects.add(key)
+            } else {
+                if (!failedDependencyProjects.contains(key)) failedDependencyProjects.add(key)
+            }
         }
     }
 
@@ -268,6 +281,12 @@ private class DownloadScreenViewModel(
         viewModelScope.cancel()
     }
 }
+
+/**
+ * 平台的接口是否返回了未找到
+ */
+private fun Throwable.isNotFound(): Boolean =
+    this is ClientRequestException && response.status.value == 404
 
 @Composable
 private fun rememberDownloadAssetsViewModel(
@@ -298,7 +317,7 @@ fun DownloadAssetsScreen(
     currentKey: TitledNavKey?,
     key: NormalNavKey.DownloadAssets,
     eventViewModel: EventViewModel,
-    onItemClicked: (PlatformClasses, PlatformVersion, iconUrl: String?, deps: List<Pair<PlatformVersion.PlatformDependency, PlatformProject>>) -> Unit,
+    onItemClicked: (PlatformClasses, PlatformVersion, iconUrl: String?, deps: List<DependencyEntry>) -> Unit,
     nestedNavKeyClass: Class<out TitledNavKey>? = null,
     versionsUIWeight: Float = 6.5f,
     projectUIWeight: Float = 3.5f,
@@ -327,7 +346,17 @@ fun DownloadAssetsScreen(
                 onReload = { viewModel.getVersions() },
                 onItemClicked = { version ->
                     val deps = version.platformDependencies().mapNotNull { dep ->
-                        viewModel.cachedDependencyProject[dep.projectId]?.let { dep to it }
+                        val key = dep.cacheKey()
+                        val project = viewModel.cachedDependencyProject[key]
+                        when {
+                            project != null -> DependencyEntry(dep, project)
+                            viewModel.notFoundDependencyProjects.contains(key) ->
+                                DependencyEntry(dep, null, notFound = true)
+                            viewModel.failedDependencyProjects.contains(key) ->
+                                DependencyEntry(dep, null)
+                            //依赖项目信息仍在获取中
+                            else -> null
+                        }
                     }
                     onItemClicked(key.classes, version, key.iconUrl, deps)
                 },
@@ -385,15 +414,6 @@ private fun Versions(
                             is DownloadAssetsVersionLoading.StartLoadPage -> {
                                 Text(
                                     text = stringResource(R.string.download_assets_loading_page_data),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                    textAlign = TextAlign.Center
-                                )
-                            }
-                            is DownloadAssetsVersionLoading.LoadingDepProject -> {
-                                val ids = viewModel.loadingProjects.joinToString(", ")
-                                Text(
-                                    text = stringResource(R.string.download_assets_loading_dep_project, ids),
                                     style = MaterialTheme.typography.labelMedium,
                                     color = MaterialTheme.colorScheme.onSurface,
                                     textAlign = TextAlign.Center

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/elements/DownloadAssetsElements.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/elements/DownloadAssetsElements.kt
@@ -107,8 +107,6 @@ sealed interface DownloadAssetsVersionLoading {
     data object StartLoadPage: DownloadAssetsVersionLoading
     /** 加载分页数据 */
     data class LoadingPage(val chunk: Int, val page: Int): DownloadAssetsVersionLoading
-    /** 正在加载并缓存依赖项目 */
-    data object LoadingDepProject: DownloadAssetsVersionLoading
 }
 
 /**

--- a/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/elements/_Download.Single.kt
+++ b/ZalithLauncher/src/main/java/com/movtery/zalithlauncher/ui/screens/content/download/assets/elements/_Download.Single.kt
@@ -18,18 +18,22 @@
 
 package com.movtery.zalithlauncher.ui.screens.content.download.assets.elements
 
+import androidx.annotation.StringRes
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -40,6 +44,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -50,12 +55,17 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -63,10 +73,14 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.movtery.zalithlauncher.R
+import com.movtery.zalithlauncher.game.download.assets.DependencyRequest
+import com.movtery.zalithlauncher.game.download.assets.platform.Platform
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformClasses
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformDependencyType
+import com.movtery.zalithlauncher.game.download.assets.platform.PlatformDisplayLabel
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformProject
 import com.movtery.zalithlauncher.game.download.assets.platform.PlatformVersion
+import com.movtery.zalithlauncher.game.download.assets.platform.cacheKey
 import com.movtery.zalithlauncher.game.version.installed.Version
 import com.movtery.zalithlauncher.game.version.installed.VersionsManager
 import com.movtery.zalithlauncher.ui.components.MarqueeText
@@ -78,6 +92,19 @@ import com.movtery.zalithlauncher.ui.theme.cardColor
 import com.movtery.zalithlauncher.ui.theme.itemColor
 import com.movtery.zalithlauncher.ui.theme.onCardColor
 import com.movtery.zalithlauncher.ui.theme.onItemColor
+import com.movtery.zalithlauncher.utils.formatNumberByLocale
+
+/**
+ * 下载对话框中的依赖项
+ * @param dependency 依赖信息
+ * @param project 依赖项目信息，为null代表信息获取失败
+ * @param notFound 依赖项目在平台上不存在
+ */
+class DependencyEntry(
+    val dependency: PlatformVersion.PlatformDependency,
+    val project: PlatformProject?,
+    val notFound: Boolean = false
+)
 
 /**
  * 操作状态：下载单个资源文件
@@ -88,19 +115,20 @@ sealed interface DownloadSingleOperation {
     data class WarningForMobileData(
         val classes: PlatformClasses,
         val version: PlatformVersion,
-        val dependencyProjects: List<Pair<PlatformVersion.PlatformDependency, PlatformProject>>
+        val dependencyEntries: List<DependencyEntry>
     ) : DownloadSingleOperation
     /** 选择版本 */
     data class SelectVersion(
         val classes: PlatformClasses,
         val version: PlatformVersion,
-        val dependencyProjects: List<Pair<PlatformVersion.PlatformDependency, PlatformProject>>
+        val dependencyEntries: List<DependencyEntry>
     ) : DownloadSingleOperation
     /** 安装 */
     data class Install(
         val classes: PlatformClasses,
         val version: PlatformVersion,
-        val versions: List<Version>
+        val versions: List<Version>,
+        val dependencies: List<DependencyRequest>
     ) : DownloadSingleOperation
 }
 
@@ -108,8 +136,9 @@ sealed interface DownloadSingleOperation {
 fun DownloadSingleOperation(
     operation: DownloadSingleOperation,
     changeOperation: (DownloadSingleOperation) -> Unit,
-    doInstall: (PlatformClasses, PlatformVersion, List<Version>) -> Unit,
-    onDependencyClicked: (PlatformVersion.PlatformDependency, PlatformClasses) -> Unit = { _, _ -> }
+    doInstall: (PlatformClasses, PlatformVersion, List<Version>, List<DependencyRequest>) -> Unit,
+    installedProjects: Map<Platform, Set<String>> = emptyMap(),
+    onDependencyClicked: (Platform, String, PlatformClasses) -> Unit = { _, _, _ -> }
 ) {
     when (operation) {
         DownloadSingleOperation.None -> {}
@@ -127,34 +156,37 @@ fun DownloadSingleOperation(
                         DownloadSingleOperation.SelectVersion(
                             classes = operation.classes,
                             version = operation.version,
-                            dependencyProjects = operation.dependencyProjects
+                            dependencyEntries = operation.dependencyEntries
                         )
                     )
                 }
             )
         }
         is DownloadSingleOperation.SelectVersion -> {
-            val dependencyProjects = operation.dependencyProjects
+            val dependencyEntries = operation.dependencyEntries
             val classes = operation.classes
 
             DownloadDialog(
-                dependencyProjects = dependencyProjects,
+                dependencyEntries = dependencyEntries,
                 classes = classes,
+                installedProjects = installedProjects,
                 onDismiss = {
                     changeOperation(DownloadSingleOperation.None)
                 },
-                onInstall = { versions ->
-                    changeOperation(DownloadSingleOperation.Install(classes, operation.version, versions))
+                onInstall = { versions, dependencies ->
+                    changeOperation(
+                        DownloadSingleOperation.Install(classes, operation.version, versions, dependencies)
+                    )
                 },
-                onDependencyClicked = { dependency, classes ->
+                onDependencyClicked = { platform, projectId, dependencyClasses ->
                     changeOperation(DownloadSingleOperation.None)
-                    onDependencyClicked(dependency, classes)
+                    onDependencyClicked(platform, projectId, dependencyClasses)
                 }
             )
         }
         is DownloadSingleOperation.Install -> {
             LaunchedEffect(Unit) {
-                doInstall(operation.classes, operation.version, operation.versions)
+                doInstall(operation.classes, operation.version, operation.versions, operation.dependencies)
                 changeOperation(DownloadSingleOperation.None)
             }
         }
@@ -173,11 +205,12 @@ private fun rememberValidVersions(): State<List<Version>> {
 
 @Composable
 private fun DownloadDialog(
-    dependencyProjects: List<Pair<PlatformVersion.PlatformDependency, PlatformProject>>,
+    dependencyEntries: List<DependencyEntry>,
     classes: PlatformClasses,
+    installedProjects: Map<Platform, Set<String>>,
     onDismiss: () -> Unit,
-    onInstall: (List<Version>) -> Unit,
-    onDependencyClicked: (PlatformVersion.PlatformDependency, PlatformClasses) -> Unit
+    onInstall: (List<Version>, List<DependencyRequest>) -> Unit,
+    onDependencyClicked: (Platform, String, PlatformClasses) -> Unit
 ) {
     val versions by rememberValidVersions()
     val version by VersionsManager.currentVersion.collectAsStateWithLifecycle()
@@ -195,13 +228,38 @@ private fun DownloadDialog(
         val selectedVersions = remember { mutableStateListOf(version0) }
 
         //拆分依赖项目、可选项目
-        val dependencies = remember(dependencyProjects) {
-            dependencyProjects.filter { it.first.type == PlatformDependencyType.REQUIRED }
+        val dependencies = remember(dependencyEntries) {
+            dependencyEntries.filter { it.dependency.type == PlatformDependencyType.REQUIRED }
         }
-        val optionals = remember(dependencyProjects) {
-            dependencyProjects.filter { it.first.type == PlatformDependencyType.OPTIONAL }
+        val optionals = remember(dependencyEntries) {
+            dependencyEntries.filter { it.dependency.type == PlatformDependencyType.OPTIONAL }
         }
         val hasDeps = dependencies.isNotEmpty() || optionals.isNotEmpty()
+
+        //用户是否手动修改过依赖的勾选状态
+        var userChangedDependencies by remember(dependencyEntries) { mutableStateOf(false) }
+
+        val selectedDependencyKeys = remember(dependencyEntries) { mutableStateListOf<String>() }
+        val onDependencySelectedChange: (String, Boolean) -> Unit = { key, checked ->
+            userChangedDependencies = true
+            if (checked) {
+                if (!selectedDependencyKeys.contains(key)) selectedDependencyKeys.add(key)
+            } else {
+                selectedDependencyKeys.remove(key)
+            }
+        }
+
+        // 默认勾选必装依赖，本地已安装的模组依赖默认不勾选
+        // 已安装信息可能晚于对话框到达，用户未手动修改过时重新套用默认状态
+        LaunchedEffect(dependencyEntries, installedProjects, userChangedDependencies) {
+            if (userChangedDependencies) return@LaunchedEffect
+            selectedDependencyKeys.clear()
+            selectedDependencyKeys.addAll(
+                dependencies
+                    .filter { it.isInstallable() && !it.isModInstalled(installedProjects, classes) }
+                    .map { it.dependency.cacheKey() }
+            )
+        }
 
         Dialog(
             onDismissRequest = onDismiss,
@@ -251,7 +309,7 @@ private fun DownloadDialog(
                                             orientation = Orientation.Vertical,
                                         ),
                                     contentPadding = PaddingValues(vertical = 8.dp),
-                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    verticalArrangement = Arrangement.spacedBy(12.dp),
                                     state = listState
                                 ) {
                                     dependencies.takeIf { it.isNotEmpty() }?.let { dependencies ->
@@ -259,6 +317,9 @@ private fun DownloadDialog(
                                             list = dependencies,
                                             titleRes = R.string.download_assets_dependency_projects,
                                             defaultClasses = classes,
+                                            selectedKeys = selectedDependencyKeys,
+                                            onSelectedChange = onDependencySelectedChange,
+                                            installedProjects = installedProjects,
                                             onDependencyClicked = onDependencyClicked
                                         )
                                     }
@@ -267,6 +328,9 @@ private fun DownloadDialog(
                                             list = optionals,
                                             titleRes = R.string.download_assets_optional_projects,
                                             defaultClasses = classes,
+                                            selectedKeys = selectedDependencyKeys,
+                                            onSelectedChange = onDependencySelectedChange,
+                                            installedProjects = installedProjects,
                                             onDependencyClicked = onDependencyClicked
                                         )
                                     }
@@ -325,7 +389,22 @@ private fun DownloadDialog(
                                 enabled = selectedVersions.isNotEmpty(),
                                 onClick = {
                                     if (selectedVersions.isNotEmpty()) {
-                                        onInstall(selectedVersions)
+                                        onInstall(
+                                            selectedVersions,
+                                            dependencyEntries.mapNotNull { entry ->
+                                                val project = entry.project ?: return@mapNotNull null
+                                                if (entry.dependency.cacheKey() !in selectedDependencyKeys) {
+                                                    return@mapNotNull null
+                                                }
+                                                DependencyRequest(
+                                                    platform = entry.dependency.platform,
+                                                    projectId = project.platformId(),
+                                                    versionId = entry.dependency.versionId,
+                                                    classes = project.platformClasses(classes),
+                                                    projectTitle = project.platformTitle()
+                                                )
+                                            }
+                                        )
                                     }
                                 }
                             ) {
@@ -422,27 +501,131 @@ private fun SelectVersionListItem(
 }
 
 private fun LazyListScope.dependencyLayout(
-    list: List<Pair<PlatformVersion.PlatformDependency, PlatformProject>>,
+    list: List<DependencyEntry>,
     titleRes: Int,
     defaultClasses: PlatformClasses,
-    onDependencyClicked: (PlatformVersion.PlatformDependency, PlatformClasses) -> Unit
+    selectedKeys: List<String>,
+    onSelectedChange: (String, Boolean) -> Unit,
+    installedProjects: Map<Platform, Set<String>>,
+    onDependencyClicked: (Platform, String, PlatformClasses) -> Unit
 ) {
-    if (list.isNotEmpty()) {
-        item {
-            Text(
-                text = stringResource(titleRes),
-                style = MaterialTheme.typography.labelLarge
-            )
-        }
-        //前置项目列表
-        items(list) { (dependency, dependencyProject) ->
-            AssetsVersionDependencyItem(
+    if (list.isEmpty()) return
+
+    item {
+        Text(
+            text = stringResource(titleRes),
+            style = MaterialTheme.typography.labelLarge
+        )
+    }
+    //前置项目列表
+    items(list) { entry ->
+        val dependency = entry.dependency
+        val project = entry.project
+        if (project == null) {
+            //依赖项目信息获取失败，展示占位项且不可选
+            AssetsUnavailableDependencyItem(
                 modifier = Modifier.fillMaxWidth(),
-                project = dependencyProject,
-                onClick = {
-                    onDependencyClicked(dependency, dependencyProject.platformClasses(defaultClasses))
+                title = dependency.projectId ?: dependency.versionId.orEmpty(),
+                statusRes = if (entry.notFound) {
+                    R.string.download_assets_id_not_found
+                } else {
+                    R.string.download_assets_dependency_project_unavailable
                 }
             )
+            return@items
+        }
+
+        val key = dependency.cacheKey()
+        val dependencyClasses = project.platformClasses(defaultClasses)
+        AssetsVersionDependencyItem(
+            modifier = Modifier.fillMaxWidth(),
+            project = project,
+            checked = selectedKeys.contains(key),
+            onCheckedChange = { onSelectedChange(key, it) },
+            installed = dependencyClasses == PlatformClasses.MOD &&
+                    installedProjects[dependency.platform]?.contains(project.platformId()) == true,
+            onClick = {
+                onDependencyClicked(dependency.platform, project.platformId(), dependencyClasses)
+            }
+        )
+    }
+}
+
+/**
+ * 是否可安装：依赖项目信息获取成功的才能被选中安装
+ */
+private fun DependencyEntry.isInstallable(): Boolean = project != null
+
+/**
+ * 该依赖是否为本地已安装的模组项目
+ */
+private fun DependencyEntry.isModInstalled(
+    installedProjects: Map<Platform, Set<String>>,
+    defaultClasses: PlatformClasses
+): Boolean {
+    val project = project ?: return false
+    return project.platformClasses(defaultClasses) == PlatformClasses.MOD &&
+            installedProjects[dependency.platform]?.contains(project.platformId()) == true
+}
+
+/**
+ * 依赖项目信息获取失败时的占位项
+ */
+@Composable
+private fun AssetsUnavailableDependencyItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    @StringRes statusRes: Int,
+    shape: Shape = MaterialTheme.shapes.large,
+    color: Color = itemColor(false),
+    contentColor: Color = onItemColor(),
+) {
+    Surface(
+        modifier = modifier,
+        shape = shape,
+        color = color,
+        contentColor = contentColor,
+    ) {
+        Column(
+            modifier = Modifier.padding(all = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                AssetsIcon(
+                    modifier = Modifier.clip(shape = RoundedCornerShape(10.dp)),
+                    size = 48.dp,
+                    iconUrl = null
+                )
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    modifier = Modifier.height(28.dp),
+                    checked = false,
+                    onCheckedChange = null
+                )
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = stringResource(statusRes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }
@@ -451,6 +634,9 @@ private fun LazyListScope.dependencyLayout(
 private fun AssetsVersionDependencyItem(
     modifier: Modifier = Modifier,
     project: PlatformProject,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    installed: Boolean,
     onClick: () -> Unit = {},
     shape: Shape = MaterialTheme.shapes.large,
     color: Color = itemColor(false),
@@ -461,6 +647,9 @@ private fun AssetsVersionDependencyItem(
     val title = remember { project.platformTitle() }
     val summary = remember { project.platformSummary() }
     val iconUrl = remember { project.platformIconUrl() }
+    val downloads = remember { project.platformDownloadCount() }
+    val follows = remember { project.platformFollows() }
+    val modLoaders = remember { project.platformModLoaders() }
 
     Surface(
         modifier = modifier,
@@ -470,18 +659,32 @@ private fun AssetsVersionDependencyItem(
         contentColor = contentColor,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
+            modifier = Modifier
+                .padding(all = 8.dp)
+                .height(IntrinsicSize.Min),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            AssetsIcon(
-                modifier = Modifier
-                    .padding(all = 8.dp)
-                    .clip(shape = RoundedCornerShape(10.dp)),
-                size = 48.dp,
-                iconUrl = iconUrl
-            )
             Column(
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.fillMaxHeight()
+            ) {
+                AssetsIcon(
+                    modifier = Modifier.clip(shape = RoundedCornerShape(10.dp)),
+                    size = 48.dp,
+                    iconUrl = iconUrl
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Checkbox(
+                    modifier = Modifier.height(24.dp),
+                    checked = checked,
+                    onCheckedChange = onCheckedChange
+                )
+            }
+
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 ProjectTitleHead(
                     platform = platform,
@@ -489,15 +692,122 @@ private fun AssetsVersionDependencyItem(
                     author = null //ui太小，展示不下
                 )
                 summary?.let { summary ->
-                    Text(
-                        text = summary,
-                        style = MaterialTheme.typography.bodySmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        //描述
+                        Text(
+                            modifier = Modifier.weight(1f),
+                            text = summary,
+                            style = MaterialTheme.typography.bodySmall,
+                            minLines = 2,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        AssetsDependencyCounts(
+                            downloads = downloads,
+                            follows = follows
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                //加载器标签与已安装标注
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    AssetsDependencyTags(
+                        modifier = Modifier.weight(1f),
+                        modLoaders = modLoaders
                     )
+                    if (summary == null) {
+                        //没有摘要时，计数移到底部行展示
+                        AssetsDependencyCounts(
+                            downloads = downloads,
+                            follows = follows
+                        )
+                    }
+                    if (installed) {
+                        InstalledModBadge()
+                    }
                 }
             }
-            Spacer(modifier = Modifier.width(2.dp))
+        }
+    }
+}
+
+/**
+ * 依赖项目支持的模组加载器标签
+ */
+@Composable
+private fun AssetsDependencyTags(
+    modifier: Modifier = Modifier,
+    modLoaders: List<PlatformDisplayLabel>?
+) {
+    Row(
+        modifier = modifier
+            .alpha(0.7f)
+            .basicMarquee(iterations = Int.MAX_VALUE),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        modLoaders?.forEach { modLoader ->
+            Text(
+                text = modLoader.getDisplayName(),
+                style = MaterialTheme.typography.labelSmall
+            )
+        }
+    }
+}
+
+/**
+ * 依赖项目的下载量与收藏量
+ */
+@Composable
+private fun AssetsDependencyCounts(
+    modifier: Modifier = Modifier,
+    downloads: Long,
+    follows: Long?
+) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = modifier.alpha(0.7f),
+        horizontalAlignment = Alignment.End,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(R.drawable.ic_download_2_outlined),
+                contentDescription = null
+            )
+            Text(
+                text = formatNumberByLocale(context, downloads),
+                style = MaterialTheme.typography.labelSmall
+            )
+        }
+        follows?.let {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    modifier = Modifier.size(14.dp),
+                    painter = painterResource(R.drawable.ic_favorite_outlined),
+                    contentDescription = null
+                )
+                Text(
+                    text = formatNumberByLocale(context, it),
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
         }
     }
 }

--- a/ZalithLauncher/src/main/res/values-ar/strings.xml
+++ b/ZalithLauncher/src/main/res/values-ar/strings.xml
@@ -192,6 +192,8 @@
     <string name="download_assets_install_progress_downloading">تنزيل الأصول وتثبيتها\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">تثبيت الأصول\n%s</string>
     <string name="download_assets_install_failed">فشل في تثبيت الأصول!</string>
+    <string name="download_assets_dependency_no_compatible_version">لا توجد نسخة متوافقة للتبعية %s</string>
+    <string name="download_assets_dependency_project_unavailable">معلومات المشروع غير متوفرة</string>
     <string name="download_modpack_warning1">قبل التثبيت، عليك أن تفهم أن معظم حزم التعديل مصممة لأجهزة الكمبيوتر، وهناك احتمال كبير لحدوث أعطال أو مشاكل أخرى عند محاولة تشغيلها. غالبًا ما تكون هذه المشاكل تفوق قدرة المشغل على حلها.</string>
     <string name="download_modpack_warning2">‎سوف تحتاج إلى تعلم المعرفة ذات الصلة لمحاولة حل المشكلات بنفسك، أو طلب المساعدة من الآخرين.</string>
     <string name="download_modpack_warning3">ملاحظة: لا يتعامل مطورو برنامج التشغيل عادةً مع المشكلات التي تسببها المودباكات.</string>

--- a/ZalithLauncher/src/main/res/values-es/strings.xml
+++ b/ZalithLauncher/src/main/res/values-es/strings.xml
@@ -198,6 +198,8 @@
     <string name="download_assets_install_progress_downloading">Descargando e instalando recursos\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">Instalando recursos\n%s</string>
     <string name="download_assets_install_failed">¡Error al instalar recursos!</string>
+    <string name="download_assets_dependency_no_compatible_version">No se encontró una versión compatible para la dependencia %s</string>
+    <string name="download_assets_dependency_project_unavailable">Información del proyecto no disponible</string>
     <string name="download_modpack_warning1">Antes de la instalación, debes entender que muchos de los modpacks están diseñados para PC, y existe una alta probabilidad de cierres inesperados u otros problemas al intentar ejecutarlos. Estos problemas suelen estar fuera de lo que el launcher puede resolver.</string>
     <string name="download_modpack_warning2">Deberás aprender el conocimiento necesario para intentar resolver los problemas por tu cuenta, o buscar ayuda de otros.</string>
     <string name="download_modpack_warning3">Nota: Los desarrolladores del launcher normalmente no arreglan problemas causados por modpacks.</string>

--- a/ZalithLauncher/src/main/res/values-fil/strings.xml
+++ b/ZalithLauncher/src/main/res/values-fil/strings.xml
@@ -219,6 +219,8 @@
     <string name="download_assets_install_progress_downloading">Dina-download at ini-install ang mga asset\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">Ini-install ang mga asset\n%s</string>
     <string name="download_assets_install_failed">Nabigong ma-install ang mga asset!</string>
+    <string name="download_assets_dependency_no_compatible_version">Walang katugmang bersyon na nahanap para sa dependency %s</string>
+    <string name="download_assets_dependency_project_unavailable">Hindi available ang impormasyon ng proyekto</string>
     <string name="download_modpack_warning1">Bago ang pag-install, kailangan mong maunawaan na karamihan sa mga modpack ay ginawa para sa PC, at may mataas na posibilidad ng mga pag-crash o iba pang mga isyu kapag sinubukan mong ilunsad ang mga ito. Ang mga problemang ito ay kadalasang lampas sa kayang solusyunan ng launcher.</string>
     <string name="download_modpack_warning2">Kakailanganin mong matutunan ang mga kaugnay na kaalaman upang subukang lutasin ang mga isyu nang mag-isa, o humingi ng tulong sa iba.</string>
     <string name="download_modpack_warning3">Paalala: Karaniwang hindi inaayos ng mga developer ng launcher ang mga isyung dulot ng mga modpack.</string>

--- a/ZalithLauncher/src/main/res/values-in/strings.xml
+++ b/ZalithLauncher/src/main/res/values-in/strings.xml
@@ -182,6 +182,8 @@
     <string name="download_assets_install_progress_downloading">Mengunduh dan menginstal aset\n%1$s\n(%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">Menginstal aset\n%s</string>
     <string name="download_assets_install_failed">Gagal menginstal aset!</string>
+    <string name="download_assets_dependency_no_compatible_version">Tidak ditemukan versi yang kompatibel untuk dependensi %s</string>
+    <string name="download_assets_dependency_project_unavailable">Informasi proyek tidak tersedia</string>
     <string name="download_modpack_warning1">Sebelum instalasi, perlu dipahami bahwa sebagian besar modpack dibuat untuk PC, dan saat dijalankan ada kemungkinan crash atau masalah lain yang biasanya tidak bisa diperbaiki oleh launcher.</string>
     <string name="download_modpack_warning2">Anda harus mempelajari ilmu yang relevan untuk mencoba memecahkan masalah sendiri, atau meminta bantuan dari orang lain.</string>
     <string name="download_modpack_warning3">CATATAN: Developer dari launcher biasanya tidak akan mengatasi masalah apa pun yang disebabkan oleh modpack.</string>

--- a/ZalithLauncher/src/main/res/values-ja/strings.xml
+++ b/ZalithLauncher/src/main/res/values-ja/strings.xml
@@ -184,6 +184,8 @@
     <string name="download_assets_install_progress_downloading">アセットのダウンロードとインストール\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">アセットをインストール\n%s</string>
     <string name="download_assets_install_failed">アセットのインストールに失敗しました！</string>
+    <string name="download_assets_dependency_no_compatible_version">依存関係 %s に互換性のあるバージョンが見つかりません</string>
+    <string name="download_assets_dependency_project_unavailable">プロジェクト情報を取得できません</string>
     <string name="download_modpack_warning1">インストール前に理解してください、ほとんどのモッドパックはPC向けに作られているため、起動時にクラッシュやその他の問題が発生する可能性が高いです。これらの問題は、ランチャーでは解決できない場合が多いです。</string>
     <string name="download_modpack_install_overrides">モッドパックファイルを抽出</string>
     <string name="download_modpack_download">モッドパックに必要なコンテンツをダウンロード</string>

--- a/ZalithLauncher/src/main/res/values-ko/strings.xml
+++ b/ZalithLauncher/src/main/res/values-ko/strings.xml
@@ -229,6 +229,8 @@
     <string name="download_assets_install_progress_downloading">에셋 다운로드 및 설치 중\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">에셋 설치중\n%s</string>
     <string name="download_assets_install_failed">에셋 설치 실패!</string>
+    <string name="download_assets_dependency_no_compatible_version">의존성 %s에 대한 호환 버전을 찾을 수 없습니다</string>
+    <string name="download_assets_dependency_project_unavailable">프로젝트 정보를 가져올 수 없습니다</string>
     <string name="download_modpack_warning1">설치 전 안내, 대부분의 모드팩은 PC용으로 제작되었습니다, 모바일에서 실행 시 크래시(튕김)나 기타 문제가 발생할 확률이 매우 높으며, 이는 런처 수준에서 해결하기 어려운 경우가 많습니다.</string>
     <string name="download_modpack_warning2">오류가 발생하면 스스로 해결 방법을 찾아보거나, 커뮤니티 등을 통해 주변의 도움을 구해 보세요.</string>
     <string name="download_modpack_warning3">참고: 런처 개발자는 일반적으로 모드팩으로 인해 발생하는 문제를 해결해 드리지 않습니다.</string>

--- a/ZalithLauncher/src/main/res/values-pt-rBR/strings.xml
+++ b/ZalithLauncher/src/main/res/values-pt-rBR/strings.xml
@@ -218,6 +218,8 @@
     <string name="download_assets_install_progress_downloading">Baixando e instalando recursos\n%1$s\n(%2$s/%3$s)</string>
     <string name="download_assets_install_progress_installing">Instalando recursos\n%s</string>
     <string name="download_assets_install_failed">Falha ao instalar os recursos!</string>
+    <string name="download_assets_dependency_no_compatible_version">Nenhuma versão compatível encontrada para a dependência %s</string>
+    <string name="download_assets_dependency_project_unavailable">Informações do projeto indisponíveis</string>
     <string name="download_modpack_warning1">Antes da instalação, você precisa entender que a maioria dos modpack são feitos para PC e há uma grande chance de travamentos, crashes ou outros problemas ao tentar iniciá-los. Esses problemas geralmente estão além do que o inicializador pode resolver, as vezes incompatibilidade com o Android.</string>
     <string name="download_modpack_warning2">Você precisará aprender o conhecimento relevante para tentar resolver os problemas sozinho ou procurar ajuda de outras pessoas.</string>
     <string name="download_modpack_warning3">Observação: os desenvolvedores do launcher geralmente não lidam com problemas causados por modpacks, pois isso não tem nada haver com o launcher.</string>

--- a/ZalithLauncher/src/main/res/values-pt/strings.xml
+++ b/ZalithLauncher/src/main/res/values-pt/strings.xml
@@ -236,6 +236,8 @@
     <string name="download_assets_no_installed_versions">Nenhuma versão do jogo está instalada no momento, portanto, não é possível determinar o local de download do recurso. Por favor, instale uma versão do jogo primeiro!</string>
     <string name="download_assets_install_progress_installing">Instalando recursos\n%s</string>
     <string name="download_assets_install_failed">Falha ao instalar os recursos!</string>
+    <string name="download_assets_dependency_no_compatible_version">Não foi encontrada nenhuma versão compatível para a dependência %s</string>
+    <string name="download_assets_dependency_project_unavailable">Informações do projeto indisponíveis</string>
     <string name="game_launch_no_version">Nenhuma versão do jogo selecionada!</string>
     <string name="game_launch_no_account">Nenhuma conta está logada!</string>
     <string name="game_button_force_close">Forçar Fechamento</string>

--- a/ZalithLauncher/src/main/res/values-ru/strings.xml
+++ b/ZalithLauncher/src/main/res/values-ru/strings.xml
@@ -466,6 +466,8 @@
     <string name="download_assets_install_progress_downloading">Загрузка и установка ресурсов\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">Установка ресурсов\n%s</string>
     <string name="download_assets_install_failed">Не удалось установить ресурсы!</string>
+    <string name="download_assets_dependency_no_compatible_version">Не найдено совместимой версии для зависимости %s</string>
+    <string name="download_assets_dependency_project_unavailable">Информация о проекте недоступна</string>
     <string name="download_assets_category_worldgen">Генерация мира</string>
     <string name="download_assets_category_biomes">Биомы</string>
     <string name="download_assets_category_dimensions">Измерения</string>

--- a/ZalithLauncher/src/main/res/values-th/strings.xml
+++ b/ZalithLauncher/src/main/res/values-th/strings.xml
@@ -108,6 +108,8 @@
     <string name="download_assets_install_progress_downloading">กำลังดาวโหลดและติดตั้งข้อมูล\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">กำลังติดตั้งข้อมูล\n%s</string>
     <string name="download_assets_install_failed">การติดตั้งข้อมูล ผิดพลาด</string>
+    <string name="download_assets_dependency_no_compatible_version">ไม่พบเวอร์ชันที่เข้ากันได้สำหรับการพึ่งพา %s</string>
+    <string name="download_assets_dependency_project_unavailable">ไม่สามารถดึงข้อมูลโปรเจกต์ได้</string>
     <string name="download_modpack_warning1">ก่อนที่จะทำหารติดตั้ง โปรดเข้าใจว่า Modpacks ส่วนใหญ่ทำเพื่อให้เล่นบนคอมพิวเตอร์ มีโอกาสสูงที่จะเด้งหรือปัญหาอื่นเมื่อพยายามจะเล่น. ปัญหาพวกนั้นอยู่นอกเหนือสิ่งที่Luncherแก้ได้</string>
     <string name="download_modpack_warning2">โปรดเรียนรู้เกี่ยวกับปัญหา และพยายาที่จะแก้ด้วยตนเองหรือขอความช่วยเหลือจากผู้อื่น</string>
     <string name="download_modpack_warning3">ปล. โดยปกติผู้พัฒนาLuncherไม่ได้แก้ปัญหาที่เกิดจากmodpacks</string>

--- a/ZalithLauncher/src/main/res/values-tr/strings.xml
+++ b/ZalithLauncher/src/main/res/values-tr/strings.xml
@@ -197,6 +197,8 @@
     <string name="download_assets_install_progress_downloading">Varlıklar indiriliyor ve yükleniyor\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">Varlıklar yükleniyor\n%s</string>
     <string name="download_assets_install_failed">Varlıklar yüklenemedi!</string>
+    <string name="download_assets_dependency_no_compatible_version">%s bağımlılığı için uyumlu sürüm bulunamadı</string>
+    <string name="download_assets_dependency_project_unavailable">Proje bilgileri alınamadı</string>
     <string name="download_modpack_warning1">Kurulumdan önce, çoğu mod paketinin PC için yapıldığını ve bunları başlatmaya çalıştığınızda çökme veya başka sorunlar yaşama olasılığının yüksek olduğunu anlamanız gerekir. Bu sorunlar genellikle tahmin edilemeyecek kadar büyüktür.</string>
     <string name="download_modpack_warning2">Sorunları kendi başınıza çözmeye çalışmak veya başkalarından yardım almak için ilgili bilgileri öğrenmeniz gerekecektir.</string>
     <string name="download_modpack_warning3">Not: Başlatıcı geliştiricileri genellikle mod paketlerinden kaynaklanan sorunları çözmez.</string>

--- a/ZalithLauncher/src/main/res/values-vi/strings.xml
+++ b/ZalithLauncher/src/main/res/values-vi/strings.xml
@@ -171,6 +171,8 @@
     <string name="download_assets_install_progress_downloading">Đang tải và cài đặt\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">Đang cài\n%s</string>
     <string name="download_assets_install_failed">Cài thất bại!</string>
+    <string name="download_assets_dependency_no_compatible_version">Không tìm thấy phiên bản tương thích cho phụ thuộc %s</string>
+    <string name="download_assets_dependency_project_unavailable">Không thể tải thông tin dự án</string>
     <string name="download_assets_category_worldgen">Tạo thế giới</string>
     <string name="download_assets_category_dimensions">Chiều không gian</string>
     <string name="download_assets_category_ores_resources">Khoáng sản</string>

--- a/ZalithLauncher/src/main/res/values-zh-rCN/strings.xml
+++ b/ZalithLauncher/src/main/res/values-zh-rCN/strings.xml
@@ -266,6 +266,8 @@
     <string name="download_assets_install_progress_downloading">下载安装资源中\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">安装资源中\n%s</string>
     <string name="download_assets_install_failed">安装资源失败！</string>
+    <string name="download_assets_dependency_no_compatible_version">依赖 %s 未找到适配的版本</string>
+    <string name="download_assets_dependency_project_unavailable">依赖项目信息获取失败</string>
     <string name="download_assets_id_holder">项目 ID</string>
     <string name="download_assets_id_tip">根据项目 ID 快速获取对应项目</string>
     <string name="download_assets_id_not_found">未找到该项目！</string>

--- a/ZalithLauncher/src/main/res/values-zh-rTW/strings.xml
+++ b/ZalithLauncher/src/main/res/values-zh-rTW/strings.xml
@@ -1119,6 +1119,8 @@
     <string name="download_assets_install_progress_downloading">下載並安裝資源\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">安裝資源\n%s</string>
     <string name="download_assets_install_failed">安裝資源失敗!</string>
+    <string name="download_assets_dependency_no_compatible_version">依賴 %s 未找到適配的版本</string>
+    <string name="download_assets_dependency_project_unavailable">無法取得依賴專案資訊</string>
     <string name="download_assets_id_holder">專案 ID</string>
     <string name="download_assets_id_tip">根據專案 ID 快速取得對應專案</string>
     <string name="download_assets_id_not_found">未找到該專案！</string>

--- a/ZalithLauncher/src/main/res/values/strings.xml
+++ b/ZalithLauncher/src/main/res/values/strings.xml
@@ -265,6 +265,8 @@
     <string name="download_assets_install_progress_downloading">Downloading and installing assets\n%1$s\n (%2$s / %3$s)</string>
     <string name="download_assets_install_progress_installing">Installing assets\n%s</string>
     <string name="download_assets_install_failed">Failed to install assets!</string>
+    <string name="download_assets_dependency_no_compatible_version">No compatible version was found for dependency %s</string>
+    <string name="download_assets_dependency_project_unavailable">Project information is unavailable</string>
     <string name="download_assets_id_holder">Project ID</string>
     <string name="download_assets_id_tip">Quickly get the corresponding project by project ID</string>
     <string name="download_assets_id_not_found">Project not found!</string>


### PR DESCRIPTION
- 依赖前置/可选项目新增勾选框，必装默认勾选、可选默认不勾，随主资源一并安装
- 安装时单任务展开整张依赖图：递归必装依赖、按项目认领目标版本防环与去重、项目数上限兜底
- 精确版本依赖（Modrinth version_id）直接安装指定版本；宽泛依赖按各目标版本的 MC 与加载器自动选取最新适配版本
- 模组类型依赖在目标版本已安装时跳过，不重复下载也不展开其子树
- 依赖条目大卡片化：平台/标题/作者/摘要/下载计数/加载器标签/已安装标注，标签行贴底
- 依赖项目信息改为后台异步缓存，不再阻塞版本列表加载；获取失败的依赖以占位项展示
- 本地已安装检测抽取为 InstalledModMatcher，供模组页标注与安装任务共用
Close: #1675 #1416 #1285 #1091